### PR TITLE
tests: Add --app-env option for verifier

### DIFF
--- a/tests/verifier/lib/TE/Utility.pm
+++ b/tests/verifier/lib/TE/Utility.pm
@@ -407,8 +407,11 @@ sub te_def_server_proc
 
     if (@_ > 0)
     {
-        my $cmd = "$_common->{app_path}\/$_common->{app} "; 
-        $cmd .= join(" ", @_);
+        my $cmd = "";
+        $cmd .= "env $_common->{app_env}" if exists($_common->{app_env}) && defined($_common->{app_env});
+        $cmd .= " $_common->{app_path}\/$_common->{app} ";
+        $cmd .= join(' ', @_);
+        $cmd .= " $_common->{app_arg} " if exists($_common->{app_arg}) && defined($_common->{app_arg});
         $cmd =~ s/TARGET\(\)/$_current->{target}/;
         if ($cmd =~ /FEED\(.*\)/)
         {
@@ -432,8 +435,11 @@ sub te_def_client_proc
 
     if (@_ > 0)
     {
-        my $cmd = "$_common->{app_path}\/$_common->{app} "; 
-        $cmd .= join(" ", @_);
+        my $cmd = "";
+        $cmd .= "env $_common->{app_env}" if exists($_common->{app_env}) && defined($_common->{app_env});
+        $cmd .= " $_common->{app_path}\/$_common->{app} ";
+        $cmd .= join(' ', @_);
+        $cmd .= " $_common->{app_arg} " if exists($_common->{app_arg}) && defined($_common->{app_arg});
         $cmd =~ s/TARGET\(\)/$_current->{target}/;
         if ($cmd =~ /FEED\(.*\)/)
         {


### PR DESCRIPTION
This option is common for server/client. Main purpose of
one is to support flexible way to extend command line.
It allows to provide environment variables for launching line.

Example: -e "VMA_TX_BUFS=100000 VMA_RX_BUFS=100000"

Signed-off-by: Igor Ivanov igor.ivanov.va@gmail.com

@avnerbh could you review
