### PR TITLE
update Feed File mode (IOMux) to use epoll by default

### DIFF
--- a/doc/main.dox
+++ b/doc/main.dox
@@ -116,10 +116,10 @@ sockperf: [tid 4857] using select() to block on socket(s)
  -i      --ip                 	Listen on/send to ip <ip>.
  -p      --port               	Listen on/connect to port <port> (default 11111).
  -m      --msg-size           	Use messages of size <size> bytes (minimum default 14).
- -f      --file               	Tread multiple ip+port combinations from file <file> 
-                                (server uses select).
+ -f      --file               	Read multiple ip+port combinations from file <file> 
+                                (will use IO muxer '-F' such as epoll, poll or select)
  -F      --io-hanlder-type    	Type of multiple file descriptors handle 
-                                [s|select|p|poll|e|epoll](default select).
+                                [s|select|p|poll|e|epoll](default epoll).
  -a      --activity           	Measure activity by printing a '.' for the last 
                                 <N> packets processed.
  -A      --Activity           	Measure activity by printing the duration for last 

--- a/src/SockPerf.cpp
+++ b/src/SockPerf.cpp
@@ -168,7 +168,7 @@ static const AOPT_DESC  common_opt_desc[] =
 	},
 	{
 		'f', AOPT_ARG, aopt_set_literal( 'f' ), aopt_set_string( "file" ),
-		"Tread multiple ip+port combinations from file <file> (server uses select)."
+		"Read multiple ip+port combinations from file <file> (will use IO muxer '-F' such as epoll, poll or select)"
 	},
 	{
 		'F', AOPT_ARG, aopt_set_literal( 'F' ), aopt_set_string( "iomux-type" ),
@@ -177,7 +177,7 @@ static const AOPT_DESC  common_opt_desc[] =
 #elif __FreeBSD__
 		"Type of multiple file descriptors handle [s|select|p|poll|r|recvfrom](default select)."
 #else
-		"Type of multiple file descriptors handle [s|select|p|poll|e|epoll|r|recvfrom](default select)."
+		"Type of multiple file descriptors handle [s|select|p|poll|e|epoll|r|recvfrom](default epoll)."
 #endif
 	},
 	{
@@ -1663,7 +1663,11 @@ static int parse_common_opt( const AOPT_OBJECT *common_obj )
 				if (optarg) {
 					strncpy(feedfile_name, optarg, MAX_ARGV_SIZE);
 					feedfile_name[MAX_PATH_LENGTH - 1] = '\0';
+#if defined(WIN32) && defined(__FreeBSD__)
 					s_user_params.fd_handler_type = SELECT;
+#else
+					s_user_params.fd_handler_type = EPOLL;
+#endif
 				}
 				else {
 					log_msg("'-%c' Invalid value", 'f');


### PR DESCRIPTION
epoll performance is better then select/poll so we want to use it by default.

Signed-off-by: Alex Rosenbaum alexr@mellanox.com
