### PR TITLE
Add '99.999%' percentile reporting in client ping-pong and underload tests

### DIFF
--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -69,7 +69,7 @@ void printPercentiles(FILE* f, TicksDuration* pLat, size_t size)
 {
 	qsort(pLat, size, sizeof(TicksDuration), TicksDuration::compare);
 
-	double percentile[] = {0.9999, 0.999, 0.995, 0.99, 0.95, 0.90, 0.75, 0.50, 0.25};
+	double percentile[] = {0.99999, 0.9999, 0.999, 0.99, 0.90, 0.75, 0.50, 0.25};
 	int num = sizeof(percentile)/sizeof(percentile[0]);
 	double observationsInPercentile = (double)size/100;
 
@@ -79,7 +79,7 @@ void printPercentiles(FILE* f, TicksDuration* pLat, size_t size)
 	for (int i = 0; i < num; i++) {
 		int index = (int)( 0.5 + percentile[i]*size ) - 1;
 		if (index >= 0) {
-			log_msg_file2(f, "---> percentile %6.2lf = %8.3lf", 100*percentile[i], pLat[index].toDecimalUsec());
+			log_msg_file2(f, "---> percentile %6.3lf = %8.3lf", 100*percentile[i], pLat[index].toDecimalUsec());
 		}
 	}
 	log_msg_file2(f, "---> <MIN> observation = %8.3lf", pLat[0].toDecimalUsec());


### PR DESCRIPTION
1. Report the '99.999%': provide better reporting by sockperf measurement
   tool now that low latency network solutions (like VMA) are reaching better
   performance.
2. Remove the '99.50%' and '95.00%'

Example of new output:

  sockperf: Total 5303071 observations; each percentile contains 53030.71 observations
  sockperf: ---> MAX observation =   42.328
  sockperf: ---> percentile 99.999 =    7.946  <=== New report
  sockperf: ---> percentile 99.990 =    4.565
  sockperf: ---> percentile 99.900 =    4.138
  sockperf: ---> percentile 99.000 =    2.236
  sockperf: ---> percentile 90.000 =    1.931
  sockperf: ---> percentile 75.000 =    1.895
  sockperf: ---> percentile 50.000 =    1.861
  sockperf: ---> percentile 25.000 =    1.796
  sockperf: ---> MIN observation =    1.743

Signed-off-by: Alex Rosenbaum Alexr@mellanox.com
