### PR TITLE
Add --use-dummy parameter to support VMA's Dummy send feature.

### DIFF
--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -706,8 +706,13 @@ void client_handler(int _fd_min, int _fd_max, int _fd_num) {
 //------------------------------------------------------------------------------
 template <class IoType, class SwitchDataIntegrity, class SwitchActivityInfo>
 void client_handler(int _fd_min, int _fd_max, int _fd_num) {
-	if (g_pApp->m_const_params.cycleDuration > TicksDuration::TICKS0)
-		client_handler<IoType, SwitchDataIntegrity, SwitchActivityInfo, SwitchOnCycleDuration> (_fd_min, _fd_max, _fd_num);
+	if (g_pApp->m_const_params.cycleDuration > TicksDuration::TICKS0) {
+		if (g_pApp->m_const_params.b_dummy_send) {
+			client_handler<IoType, SwitchDataIntegrity, SwitchActivityInfo, SwitchOnDummySend> (_fd_min, _fd_max, _fd_num);
+		} else {
+			client_handler<IoType, SwitchDataIntegrity, SwitchActivityInfo, SwitchOnCycleDuration> (_fd_min, _fd_max, _fd_num);
+		}
+	}
 	else
 		client_handler<IoType, SwitchDataIntegrity, SwitchActivityInfo, SwitchOff> (_fd_min, _fd_max, _fd_num);
 }

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -707,7 +707,7 @@ void client_handler(int _fd_min, int _fd_max, int _fd_num) {
 template <class IoType, class SwitchDataIntegrity, class SwitchActivityInfo>
 void client_handler(int _fd_min, int _fd_max, int _fd_num) {
 	if (g_pApp->m_const_params.cycleDuration > TicksDuration::TICKS0) {
-		if (g_pApp->m_const_params.dummy_send) {
+		if (g_pApp->m_const_params.dummy_mps) {
 			client_handler<IoType, SwitchDataIntegrity, SwitchActivityInfo, SwitchOnDummySend> (_fd_min, _fd_max, _fd_num);
 		} else {
 			client_handler<IoType, SwitchDataIntegrity, SwitchActivityInfo, SwitchOnCycleDuration> (_fd_min, _fd_max, _fd_num);

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -707,7 +707,7 @@ void client_handler(int _fd_min, int _fd_max, int _fd_num) {
 template <class IoType, class SwitchDataIntegrity, class SwitchActivityInfo>
 void client_handler(int _fd_min, int _fd_max, int _fd_num) {
 	if (g_pApp->m_const_params.cycleDuration > TicksDuration::TICKS0) {
-		if (g_pApp->m_const_params.b_dummy_send) {
+		if (g_pApp->m_const_params.dummy_send) {
 			client_handler<IoType, SwitchDataIntegrity, SwitchActivityInfo, SwitchOnDummySend> (_fd_min, _fd_max, _fd_num);
 		} else {
 			client_handler<IoType, SwitchDataIntegrity, SwitchActivityInfo, SwitchOnCycleDuration> (_fd_min, _fd_max, _fd_num);

--- a/src/Client.h
+++ b/src/Client.h
@@ -313,7 +313,7 @@ private:
 		m_switchMsgSize.execute(m_pMsgRequest);
 
 		//idle
-		m_switchCycleDuration.execute(ifd, m_pMsgRequest->getLength());
+		m_switchCycleDuration.execute(m_pMsgRequest, ifd);
 
 		//send
 		for (unsigned i = 0; i < g_pApp->m_const_params.burst_size && !g_b_exit; i++) {

--- a/src/Client.h
+++ b/src/Client.h
@@ -313,7 +313,7 @@ private:
 		m_switchMsgSize.execute(m_pMsgRequest);
 
 		//idle
-		m_switchCycleDuration.execute();
+		m_switchCycleDuration.execute(ifd, m_pMsgRequest->getLength());
 
 		//send
 		for (unsigned i = 0; i < g_pApp->m_const_params.burst_size && !g_b_exit; i++) {

--- a/src/Defs.h
+++ b/src/Defs.h
@@ -187,7 +187,8 @@ enum {
 	OPT_CLIENTIP,                   //37
 	OPT_TOS,                        //38
 	OPT_LLS,                        //39
-	OPT_MC_SOURCE_IP                //40
+	OPT_MC_SOURCE_IP,               //40
+	OPT_DUMMY_SEND                  //41
 };
 
 #define MODULE_NAME			"sockperf"
@@ -603,6 +604,7 @@ struct user_params_t {
 	int tos;
 	unsigned int lls_usecs;
 	bool lls_is_set;
+	bool b_dummy_send; //client side only
 };
 
 struct mutable_params_t {

--- a/src/Defs.h
+++ b/src/Defs.h
@@ -147,6 +147,8 @@ extern const int MAX_FDS_NUM;
 #define DEFAULT_SELECT_TIMEOUT_MSEC	10
 #define DEFAULT_DEBUG_LEVEL			0
 
+#define DUMMY_SEND_FLAG MSG_SYN // Used by offload libraries to do egress path warm-up of caches. It is not in use by kernel. WARNING: it will actually end this packet on the wire.
+#define DUMMY_SEND_MPS_DEFAULT 10000
 
 enum {
 	OPT_RX_MC_IF 			 = 1,
@@ -604,7 +606,9 @@ struct user_params_t {
 	int tos;
 	unsigned int lls_usecs;
 	bool lls_is_set;
-	bool b_dummy_send; //client side only
+	bool dummy_send; //client side only
+	uint32_t dummy_mps; //client side only
+	TicksDuration dummySendCycleDuration; //client side only
 };
 
 struct mutable_params_t {

--- a/src/Defs.h
+++ b/src/Defs.h
@@ -150,7 +150,7 @@ extern const int MAX_FDS_NUM;
 /*
 Used by offload libraries to do egress path warm-up of caches.
 It is not in use by kernel. WARNING: it will actually end this packet on the wire.
-More info at vma_extra.h
+DUMMY_SEND_FLAG value should be compatible with the value of VMA_SND_FLAGS_DUMMY (More info at vma_extra.h).
 */
 #define DUMMY_SEND_FLAG MSG_SYN // equals to 0x400
 #define DUMMY_SEND_MPS_DEFAULT 10000

--- a/src/Defs.h
+++ b/src/Defs.h
@@ -147,7 +147,12 @@ extern const int MAX_FDS_NUM;
 #define DEFAULT_SELECT_TIMEOUT_MSEC	10
 #define DEFAULT_DEBUG_LEVEL			0
 
-#define DUMMY_SEND_FLAG MSG_SYN // Used by offload libraries to do egress path warm-up of caches. It is not in use by kernel. WARNING: it will actually end this packet on the wire.
+/*
+Used by offload libraries to do egress path warm-up of caches.
+It is not in use by kernel. WARNING: it will actually end this packet on the wire.
+More info at vma_extra.h
+*/
+#define DUMMY_SEND_FLAG MSG_SYN // equals to 0x400
 #define DUMMY_SEND_MPS_DEFAULT 10000
 
 enum {
@@ -606,7 +611,6 @@ struct user_params_t {
 	int tos;
 	unsigned int lls_usecs;
 	bool lls_is_set;
-	bool dummy_send; //client side only
 	uint32_t dummy_mps; //client side only
 	TicksDuration dummySendCycleDuration; //client side only
 };

--- a/src/SockPerf.cpp
+++ b/src/SockPerf.cpp
@@ -277,10 +277,6 @@ static const AOPT_DESC  common_opt_desc[] =
 		"Set socket accleration before run (available for some of Mellanox systems)"
 	},
 	{
-		OPT_DUMMY_SEND, AOPT_NOARG,	aopt_set_literal( 0 ),	aopt_set_string( "use-dummy" ),
-		"Use dummy send instead of busy wait."
-	},
-	{
 		'd', AOPT_NOARG, aopt_set_literal( 'd' ),	aopt_set_string( "debug" ),
 		"Print extra debug information."
 	},
@@ -315,6 +311,10 @@ static const AOPT_DESC  client_opt_desc[] =
 	{
 		OPT_OUTPUT_PRECISION, AOPT_NOARG,	aopt_set_literal( 0 ),	aopt_set_string( "increase_output_precision" ),
 		"Increase number of digits after decimal point of the throughput output (from 3 to 9). "
+	},
+	{
+		OPT_DUMMY_SEND, AOPT_NOARG,	aopt_set_literal( 0 ),	aopt_set_string( "dummy-send" ),
+		"Use dummy send instead of busy wait."
 	},
 	{ 0, AOPT_NOARG, aopt_set_literal( 0 ), aopt_set_string( NULL ), NULL }
 };
@@ -1956,11 +1956,6 @@ static int parse_common_opt( const AOPT_OBJECT *common_obj )
 		if ( !rc && aopt_check(common_obj, OPT_SOCK_ACCL) ) {
 			s_user_params.withsock_accl = true;
 		}
-
-		if ( !rc && aopt_check(common_obj, OPT_DUMMY_SEND) ) {
-			s_user_params.b_dummy_send = true;
-		}
-
 #ifndef WIN32
 
 		if ( !rc && aopt_check(common_obj, OPT_VMAZCOPYREAD) ) {
@@ -2101,6 +2096,9 @@ static int parse_client_opt( const AOPT_OBJECT *client_obj )
 		}
 		if ( !rc && aopt_check(client_obj, OPT_OUTPUT_PRECISION) ) {
 			s_user_params.increase_output_precision = true;
+		}
+		if ( !rc && aopt_check(client_obj, OPT_DUMMY_SEND) ) {
+			s_user_params.b_dummy_send = true;
 		}
 	}
 

--- a/src/SockPerf.cpp
+++ b/src/SockPerf.cpp
@@ -313,8 +313,8 @@ static const AOPT_DESC  client_opt_desc[] =
 		"Increase number of digits after decimal point of the throughput output (from 3 to 9). "
 	},
 	{
-		OPT_DUMMY_SEND, AOPT_NOARG,	aopt_set_literal( 0 ),	aopt_set_string( "dummy-send" ),
-		"Use dummy send instead of busy wait."
+		OPT_DUMMY_SEND, AOPT_OPTARG,	aopt_set_literal( 0 ),	aopt_set_string( "dummy-send" ),
+		"Use dummy-send instead of busy wait. optional: set dummy-send rate per second (default 10000). usage: --dummy-send <rate>"
 	},
 	{ 0, AOPT_NOARG, aopt_set_literal( 0 ), aopt_set_string( NULL ), NULL }
 };
@@ -2098,7 +2098,24 @@ static int parse_client_opt( const AOPT_OBJECT *client_obj )
 			s_user_params.increase_output_precision = true;
 		}
 		if ( !rc && aopt_check(client_obj, OPT_DUMMY_SEND) ) {
-			s_user_params.b_dummy_send = true;
+			s_user_params.dummy_send = true;
+			const char* optarg = aopt_value(client_obj, OPT_DUMMY_SEND);
+			if (optarg) {
+				if (0 == strcmp("MAX", optarg) || 0 == strcmp("max", optarg)) {
+					s_user_params.dummy_mps = UINT32_MAX;
+				}
+				else {
+					errno = 0;
+					int value = strtol(optarg, NULL, 0);
+					if (errno != 0  || value <= 0 || value > 1<<30) {
+						log_msg("'-%d' Invalid value of dummy send rate : %s", OPT_DUMMY_SEND, optarg);
+						rc = SOCKPERF_ERR_BAD_ARGUMENT;
+					}
+					else {
+						s_user_params.dummy_mps = (uint32_t)value;
+					}
+				}
+			}
 		}
 	}
 
@@ -2297,7 +2314,8 @@ void set_defaults()
 	s_user_params.daemonize = false;
 
 	s_user_params.withsock_accl = false;
-	s_user_params.b_dummy_send = false;
+	s_user_params.dummy_send = false;
+	s_user_params.dummy_mps = DUMMY_SEND_MPS_DEFAULT;
 	memset(s_user_params.feedfile_name, 0, sizeof(s_user_params.feedfile_name));
 	s_user_params.tos = 0x00;
 }
@@ -3213,6 +3231,16 @@ int bringup(const int *p_daemonize)
 			log_msg("Number of threads should be less than sockets count");
 			rc = SOCKPERF_ERR_BAD_ARGUMENT;
 		}
+
+		if ( !rc && s_user_params.dummy_send && s_user_params.mps == UINT32_MAX) {
+			log_err("Dummy send is not supported when message-rate = MAX");
+			rc = SOCKPERF_ERR_BAD_ARGUMENT;
+		}
+
+		if ( !rc && s_user_params.dummy_send && s_user_params.mps > s_user_params.dummy_mps) {
+			log_err("Dummy send is not supported when message-rate is greater then the dummy-message-rate");
+			rc = SOCKPERF_ERR_BAD_ARGUMENT;
+		}
 	}
 
 	/* Setup internal data */
@@ -3234,6 +3262,11 @@ int bringup(const int *p_daemonize)
 		}
 
 		s_user_params.cycleDuration = TicksDuration(cycleDurationNsec);
+
+		if (s_user_params.dummy_send) { // Calculate dummy send rate
+			int64_t dummySendCycleDurationNsec = (s_user_params.dummy_mps == UINT32_MAX) ? 0 : NSEC_IN_SEC / s_user_params.dummy_mps;
+			s_user_params.dummySendCycleDuration = TicksDuration(dummySendCycleDurationNsec);
+		}
 
 		uint64_t _maxTestDuration = 1 + s_user_params.sec_test_duration;       // + 1sec for timer inaccuracy safety
 		uint64_t _maxSequenceNo = _maxTestDuration * s_user_params.mps + 10 * s_user_params.reply_every; // + 10 replies for safety

--- a/src/SockPerf.cpp
+++ b/src/SockPerf.cpp
@@ -277,6 +277,10 @@ static const AOPT_DESC  common_opt_desc[] =
 		"Set socket accleration before run (available for some of Mellanox systems)"
 	},
 	{
+		OPT_DUMMY_SEND, AOPT_NOARG,	aopt_set_literal( 0 ),	aopt_set_string( "use-dummy" ),
+		"Use dummy send instead of busy wait."
+	},
+	{
 		'd', AOPT_NOARG, aopt_set_literal( 'd' ),	aopt_set_string( "debug" ),
 		"Print extra debug information."
 	},
@@ -1952,6 +1956,11 @@ static int parse_common_opt( const AOPT_OBJECT *common_obj )
 		if ( !rc && aopt_check(common_obj, OPT_SOCK_ACCL) ) {
 			s_user_params.withsock_accl = true;
 		}
+
+		if ( !rc && aopt_check(common_obj, OPT_DUMMY_SEND) ) {
+			s_user_params.b_dummy_send = true;
+		}
+
 #ifndef WIN32
 
 		if ( !rc && aopt_check(common_obj, OPT_VMAZCOPYREAD) ) {
@@ -2290,6 +2299,7 @@ void set_defaults()
 	s_user_params.daemonize = false;
 
 	s_user_params.withsock_accl = false;
+	s_user_params.b_dummy_send = false;
 	memset(s_user_params.feedfile_name, 0, sizeof(s_user_params.feedfile_name));
 	s_user_params.tos = 0x00;
 }

--- a/src/Switches.h
+++ b/src/Switches.h
@@ -47,7 +47,7 @@ public:
 	inline void execute(struct sockaddr_in *clt_addr, uint64_t seq_num, bool is_warmup) {}
 	inline void execute(Message *pMsgRequest, Message * pMsgReply) {}
 	inline void execute(Message *pMsgRequest) {}
-	inline void execute(int ifd, int buffer_size) {}
+	inline void execute(Message *pMsgRequest, int ifd) {}
 
 /*
 	inline void execute2() {}
@@ -84,7 +84,7 @@ private:
 class SwitchOnCycleDuration {
 public:
 	//busy wait between two cycles starting point and take starting point of next cycle
-	inline void execute(int ifd = 0, int buffer_size = 0) {
+	inline void execute(Message *pMsgRequest, int ifd) {
 
 		TicksTime nextCycleStartTime = g_cycleStartTime + g_pApp->m_const_params.cycleDuration;
 		while (!g_b_exit) {
@@ -102,8 +102,8 @@ class SwitchOnDummySend {
 public:
 	// dummy send between two cycles starting point and take starting point of next cycle
 
-	inline void execute(int ifd, int buffer_size) {
-		uint8_t buffer[buffer_size];
+	inline void execute(Message *pMsgRequest, int ifd) {
+		uint8_t buffer[pMsgRequest->getLength()];
 		TicksTime nextCycleStartTime = g_cycleStartTime + g_pApp->m_const_params.cycleDuration;
 		TicksTime nextDummySendTime = g_cycleStartTime + g_pApp->m_const_params.dummySendCycleDuration;
 		while (!g_b_exit) {


### PR DESCRIPTION
WARNING - Using this parameter without VMA will cause all packets to be
sent.

Signed-off-by: Liran Oz <lirano@mellanox.com>