### PR TITLE
fix multithread zero copy crash

### DIFF
--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -472,6 +472,15 @@ int Client<IoType, SwitchDataIntegrity, SwitchActivityInfo, SwitchCycleDuration,
 	/* bind/connect socket */
 	if (rc == SOCKPERF_ERR_NONE)
 	{
+#ifdef USING_VMA_EXTRA_API
+		if (g_vma_api){
+			g_pkt_buf = new unsigned char [Message::getMaxSize()];
+			if (g_pkt_buf == NULL) {
+				log_err("Failed to allocate g_pkt_buf");
+				return SOCKPERF_ERR_NO_MEMORY;
+			}
+		}
+#endif
 		// cycle through all set fds in the array (with wrap around to beginning)
 		for (int ifd = m_ioHandler.m_fd_min; ifd <= m_ioHandler.m_fd_max; ifd++) {
 
@@ -673,6 +682,11 @@ void Client<IoType, SwitchDataIntegrity, SwitchActivityInfo, SwitchCycleDuration
 
 		cleanupAfterLoop();
 	}
+#ifdef USING_VMA_EXTRA_API
+	if (g_pkt_buf) {
+		delete [] g_pkt_buf;
+	}
+#endif
 }
 
 

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -412,6 +412,7 @@ void Client<IoType, SwitchDataIntegrity, SwitchActivityInfo, SwitchCycleDuration
 ::cleanupAfterLoop()
 {
 	usleep(100*1000);//0.1 sec - wait for rx packets for last sends (in normal flow)
+	vma_buffer_free();
 	if (m_receiverTid.tid) {
 		os_thread_kill(&m_receiverTid);
 		//os_thread_join(&m_receiverTid);
@@ -472,15 +473,9 @@ int Client<IoType, SwitchDataIntegrity, SwitchActivityInfo, SwitchCycleDuration,
 	/* bind/connect socket */
 	if (rc == SOCKPERF_ERR_NONE)
 	{
-#ifdef USING_VMA_EXTRA_API
-		if (g_vma_api) {
-			g_zero_data.pkt_buf = (unsigned char*)MALLOC(Message::getMaxSize());
-			if (g_zero_data.pkt_buf == NULL) {
-				log_err("Failed to allocate g_pkt_buf");
-				return SOCKPERF_ERR_NO_MEMORY;
-			}
-		}
-#endif
+		rc = vma_buffer_init();
+		if (rc != SOCKPERF_ERR_NONE)
+			return rc;
 		// cycle through all set fds in the array (with wrap around to beginning)
 		for (int ifd = m_ioHandler.m_fd_min; ifd <= m_ioHandler.m_fd_max; ifd++) {
 
@@ -682,11 +677,6 @@ void Client<IoType, SwitchDataIntegrity, SwitchActivityInfo, SwitchCycleDuration
 
 		cleanupAfterLoop();
 	}
-#ifdef USING_VMA_EXTRA_API
-	if (g_zero_data.pkt_buf) {
-		FREE(g_zero_data.pkt_buf);
-	}
-#endif
 }
 
 

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -473,9 +473,9 @@ int Client<IoType, SwitchDataIntegrity, SwitchActivityInfo, SwitchCycleDuration,
 	if (rc == SOCKPERF_ERR_NONE)
 	{
 #ifdef USING_VMA_EXTRA_API
-		if (g_vma_api){
-			g_pkt_buf = new unsigned char [Message::getMaxSize()];
-			if (g_pkt_buf == NULL) {
+		if (g_vma_api) {
+			g_zero_data.pkt_buf = (unsigned char*)MALLOC(Message::getMaxSize());
+			if (g_zero_data.pkt_buf == NULL) {
 				log_err("Failed to allocate g_pkt_buf");
 				return SOCKPERF_ERR_NO_MEMORY;
 			}
@@ -683,8 +683,8 @@ void Client<IoType, SwitchDataIntegrity, SwitchActivityInfo, SwitchCycleDuration
 		cleanupAfterLoop();
 	}
 #ifdef USING_VMA_EXTRA_API
-	if (g_pkt_buf) {
-		delete [] g_pkt_buf;
+	if (g_zero_data.pkt_buf) {
+		FREE(g_zero_data.pkt_buf);
 	}
 #endif
 }

--- a/src/Defs.cpp
+++ b/src/Defs.cpp
@@ -42,10 +42,10 @@ TicksTime g_cycleStartTime;
 debug_level_t g_debug_level = LOG_LVL_INFO;
 
 #ifdef  USING_VMA_EXTRA_API
-unsigned char* g_pkt_buf = NULL;
-struct vma_packets_t* g_pkts = NULL;
-unsigned int g_pkt_index = 0;
-unsigned int g_pkt_offset = 0;
+__thread unsigned char* g_pkt_buf = NULL;
+__thread struct vma_packets_t* g_pkts = NULL;
+__thread unsigned int g_pkt_index = 0;
+__thread unsigned int g_pkt_offset = 0;
 #endif
 
 

--- a/src/Defs.cpp
+++ b/src/Defs.cpp
@@ -42,10 +42,7 @@ TicksTime g_cycleStartTime;
 debug_level_t g_debug_level = LOG_LVL_INFO;
 
 #ifdef  USING_VMA_EXTRA_API
-__thread unsigned char* g_pkt_buf = NULL;
-__thread struct vma_packets_t* g_pkts = NULL;
-__thread unsigned int g_pkt_index = 0;
-__thread unsigned int g_pkt_offset = 0;
+__thread struct zero_copy_thread_data g_zero_data = {0};
 #endif
 
 

--- a/src/Defs.cpp
+++ b/src/Defs.cpp
@@ -41,8 +41,8 @@ TicksTime g_cycleStartTime;
 
 debug_level_t g_debug_level = LOG_LVL_INFO;
 
-#ifdef  USING_VMA_EXTRA_API
-__thread struct zero_copy_thread_data g_zero_data = {0};
+#ifdef USING_VMA_EXTRA_API
+THREAD_LOCAL vma_data_buffer g_zero_data = {0};
 #endif
 
 

--- a/src/Defs.h
+++ b/src/Defs.h
@@ -384,11 +384,14 @@ extern TicksTime g_cycleStartTime;
 
 extern debug_level_t g_debug_level;
 
-#ifdef  USING_VMA_EXTRA_API
-extern __thread unsigned char* g_pkt_buf;
-extern __thread struct vma_packets_t* g_pkts;
-extern __thread unsigned int g_pkt_index;
-extern __thread unsigned int g_pkt_offset;
+#ifdef USING_VMA_EXTRA_API
+typedef struct zero_copy_thread_data {
+	unsigned char* pkt_buf;
+	struct vma_packets_t* pkts;
+	unsigned int pkt_index;
+	unsigned int pkt_offset;
+}zero_copy_thread_data;
+extern __thread struct zero_copy_thread_data g_zero_data;
 #endif
 
 class Message;

--- a/src/Defs.h
+++ b/src/Defs.h
@@ -385,13 +385,17 @@ extern TicksTime g_cycleStartTime;
 extern debug_level_t g_debug_level;
 
 #ifdef USING_VMA_EXTRA_API
-typedef struct zero_copy_thread_data {
+typedef struct vma_data_buffer {
 	unsigned char* pkt_buf;
 	struct vma_packets_t* pkts;
 	unsigned int pkt_index;
 	unsigned int pkt_offset;
-}zero_copy_thread_data;
-extern __thread struct zero_copy_thread_data g_zero_data;
+}vma_data_buffer;
+extern THREAD_LOCAL struct vma_data_buffer g_zero_data;
+// https://software.intel.com/en-us/blogs/2011/05/02/the-hidden-performance-cost-of-accessing-thread-local-variables
+SP_FORCE_INLINE vma_data_buffer* get_zero_data() {
+	return &g_zero_data;
+}
 #endif
 
 class Message;

--- a/src/Defs.h
+++ b/src/Defs.h
@@ -385,10 +385,10 @@ extern TicksTime g_cycleStartTime;
 extern debug_level_t g_debug_level;
 
 #ifdef  USING_VMA_EXTRA_API
-extern unsigned char* g_pkt_buf;
-extern struct vma_packets_t* g_pkts;
-extern unsigned int g_pkt_index;
-extern unsigned int g_pkt_offset;
+extern __thread unsigned char* g_pkt_buf;
+extern __thread struct vma_packets_t* g_pkts;
+extern __thread unsigned int g_pkt_index;
+extern __thread unsigned int g_pkt_offset;
 #endif
 
 class Message;

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -358,6 +358,15 @@ void server_handler(int _fd_min, int _fd_max, int _fd_num) {
 void server_handler(handler_info *p_info)
 {
 	if (p_info) {
+#ifdef USING_VMA_EXTRA_API
+		if (g_vma_api){
+			g_pkt_buf = new unsigned char [Message::getMaxSize()];
+			if (g_pkt_buf == NULL) {
+				log_err("Failed to allocate g_pkt_buf");
+				return;
+			}
+		}
+#endif
 		switch (g_pApp->m_const_params.fd_handler_type) {
 		case RECVFROM:
 		{
@@ -391,6 +400,11 @@ void server_handler(handler_info *p_info)
 		default:
 			ERROR_MSG("unknown file handler");
 		}
+#ifdef USING_VMA_EXTRA_API
+		if (g_pkt_buf) {
+			delete [] g_pkt_buf;
+		}
+#endif
 	}
 }
 

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -358,15 +358,7 @@ void server_handler(int _fd_min, int _fd_max, int _fd_num) {
 void server_handler(handler_info *p_info)
 {
 	if (p_info) {
-#ifdef USING_VMA_EXTRA_API
-		if (g_vma_api) {
-			g_zero_data.pkt_buf = (unsigned char*)MALLOC(Message::getMaxSize());
-			if (g_zero_data.pkt_buf == NULL) {
-				log_err("Failed to allocate g_pkt_buf");
-				return;
-			}
-		}
-#endif
+		vma_buffer_init();
 		switch (g_pApp->m_const_params.fd_handler_type) {
 		case RECVFROM:
 		{
@@ -400,11 +392,7 @@ void server_handler(handler_info *p_info)
 		default:
 			ERROR_MSG("unknown file handler");
 		}
-#ifdef USING_VMA_EXTRA_API
-		if (g_zero_data.pkt_buf) {
-			FREE(g_zero_data.pkt_buf);
-		}
-#endif
+		vma_buffer_free();
 	}
 }
 

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -359,9 +359,9 @@ void server_handler(handler_info *p_info)
 {
 	if (p_info) {
 #ifdef USING_VMA_EXTRA_API
-		if (g_vma_api){
-			g_pkt_buf = new unsigned char [Message::getMaxSize()];
-			if (g_pkt_buf == NULL) {
+		if (g_vma_api) {
+			g_zero_data.pkt_buf = (unsigned char*)MALLOC(Message::getMaxSize());
+			if (g_zero_data.pkt_buf == NULL) {
 				log_err("Failed to allocate g_pkt_buf");
 				return;
 			}
@@ -401,8 +401,8 @@ void server_handler(handler_info *p_info)
 			ERROR_MSG("unknown file handler");
 		}
 #ifdef USING_VMA_EXTRA_API
-		if (g_pkt_buf) {
-			delete [] g_pkt_buf;
+		if (g_zero_data.pkt_buf) {
+			FREE(g_zero_data.pkt_buf);
 		}
 #endif
 	}

--- a/src/Server.h
+++ b/src/Server.h
@@ -124,11 +124,12 @@ void close_ifd(int fd,int ifd,fds_data* l_fds_ifd){
 	fds_data* l_next_fd =  g_fds_array[fd];
 
 #ifdef  USING_VMA_EXTRA_API
-	if (g_pkts) {
-		g_vma_api->free_packets(fd, g_pkts->pkts, g_pkts->n_packet_num);
-		g_pkts = NULL;
-		g_pkt_index = 0;
-		g_pkt_offset = 0;
+	if (g_zero_data.pkts) {
+		g_vma_api->free_packets(fd, g_zero_data.pkts->pkts,
+								g_zero_data.pkts->n_packet_num);
+		g_zero_data.pkts = NULL;
+		g_zero_data.pkt_index = 0;
+		g_zero_data.pkt_offset = 0;
 	}
 
 	if (g_vma_api) {

--- a/src/SockPerf.cpp
+++ b/src/SockPerf.cpp
@@ -2187,11 +2187,6 @@ void cleanup()
 	if(s_user_params.select_timeout) {
 		FREE(s_user_params.select_timeout);
 	}
-#ifdef  USING_VMA_EXTRA_API
-	if (g_pkt_buf) {
-		FREE(g_pkt_buf);
-	}
-#endif
 
 	if (g_fds_array)
 	{
@@ -3241,12 +3236,6 @@ int bringup(const int *p_daemonize)
 	if (!rc) {
 		int _max_buff_size = _max(s_user_params.msg_size + 1, _vma_pkts_desc_size);
 		_max_buff_size = _max(_max_buff_size, MAX_PAYLOAD_SIZE);
-
-#ifdef  USING_VMA_EXTRA_API
-		if (s_user_params.is_vmazcopyread && g_vma_api){
-			g_pkt_buf = (unsigned char*)MALLOC(_max_buff_size);
-		}
-#endif
 
 		int64_t cycleDurationNsec = NSEC_IN_SEC * s_user_params.burst_size / s_user_params.mps;
 

--- a/src/SockPerf.cpp
+++ b/src/SockPerf.cpp
@@ -2339,7 +2339,7 @@ vma_recv_callback_retval_t myapp_vma_recv_pkt_filter_callback(
 	}
 
 	//If there is data in local buffer, then push new packet in TCP queue.Otherwise handle received packet inside callback.
-	if (g_pkts && g_pkts->n_packet_num > 0) {
+	if (g_zero_data.pkts && g_zero_data.pkts->n_packet_num > 0) {
 		return VMA_PACKET_RECV;
 	}
 

--- a/src/common.h
+++ b/src/common.h
@@ -53,85 +53,99 @@ static inline int msg_recvfrom(int fd, uint8_t* buf, int nbytes, struct sockaddr
 {
 	int ret = 0;
 	socklen_t size = sizeof(struct sockaddr_in);
-    int flags = 0;
+	int flags = 0;
 
-#ifdef  USING_VMA_EXTRA_API
+#ifdef USING_VMA_EXTRA_API
 	int remain_buffer, data_to_copy;
-	uint8_t* start_addrs; 
+	uint8_t* start_addrs;
 	struct vma_packet_t *pkt;
 
 	if (g_pApp->m_const_params.is_vmazcopyread && g_vma_api) {
 		remain_buffer = nbytes;
 		// Receive held data, and free VMA's previously received zero copied packets
-		if (g_pkts && g_pkts->n_packet_num > 0) {
+		if (g_zero_data.pkts && g_zero_data.pkts->n_packet_num > 0) {
 
-			pkt = &g_pkts->pkts[0];			
-			
-			while(g_pkt_index < pkt->sz_iov) {
+			pkt = &g_zero_data.pkts->pkts[0];
+
+			while (g_zero_data.pkt_index < pkt->sz_iov) {
 				start_addrs = buf + (nbytes - remain_buffer);
-				data_to_copy = _min(remain_buffer, (int)(pkt->iov[g_pkt_index].iov_len - g_pkt_offset));
-				memcpy(start_addrs, (uint8_t*)pkt->iov[g_pkt_index].iov_base + g_pkt_offset, data_to_copy);
+				data_to_copy = _min(remain_buffer,
+								(int)(pkt->iov[g_zero_data.pkt_index].iov_len
+								- g_zero_data.pkt_offset));
+				memcpy(start_addrs,
+						(uint8_t*) pkt->iov[g_zero_data.pkt_index].iov_base +
+						g_zero_data.pkt_offset,
+						data_to_copy);
 				remain_buffer -= data_to_copy;
-				g_pkt_offset += data_to_copy;
-				
-				//Handled buffer is filled
-				if (g_pkt_offset < pkt->iov[g_pkt_index].iov_len)	return nbytes;
+				g_zero_data.pkt_offset += data_to_copy;
 
-				g_pkt_offset = 0;
-				g_pkt_index++;
+				//Handled buffer is filled
+				if (g_zero_data.pkt_offset <
+						pkt->iov[g_zero_data.pkt_index].iov_len)
+					return nbytes;
+
+				g_zero_data.pkt_offset = 0;
+				g_zero_data.pkt_index++;
 			}
-			
-			g_vma_api->free_packets(fd, g_pkts->pkts, g_pkts->n_packet_num);
-			g_pkts = NULL;
-			g_pkt_index = 0;
-			g_pkt_offset = 0;
-			
+
+			g_vma_api->free_packets(fd, g_zero_data.pkts->pkts,
+									g_zero_data.pkts->n_packet_num);
+			g_zero_data.pkts = NULL;
+			g_zero_data.pkt_index = 0;
+			g_zero_data.pkt_offset = 0;
+
 			//Handled buffer is filled
-			if (remain_buffer == 0) return nbytes;
+			if (remain_buffer == 0)
+				return nbytes;
 		}
-		
+
 		// Receive the next packet with zero copy API
-		ret = g_vma_api->recvfrom_zcopy(fd, g_pkt_buf, Message::getMaxSize(), &flags, (struct sockaddr*)recvfrom_addr, &size);
-		
+		ret = g_vma_api->recvfrom_zcopy(fd, g_zero_data.pkt_buf,
+										Message::getMaxSize(), &flags,
+										(struct sockaddr*)recvfrom_addr,
+										&size);
+
 		if (ret > 0) {
 			// Zcopy receive is perfomed
 			if (flags & MSG_VMA_ZCOPY) {
-				g_pkts = (struct vma_packets_t*)g_pkt_buf;
-				if (g_pkts->n_packet_num > 0) {
-
-					pkt = &g_pkts->pkts[0];
-
-					while(g_pkt_index < pkt->sz_iov) {
+				g_zero_data.pkts = (struct vma_packets_t*)g_zero_data.pkt_buf;
+				if (g_zero_data.pkts->n_packet_num > 0) {
+					pkt = &g_zero_data.pkts->pkts[0];
+					while (g_zero_data.pkt_index < pkt->sz_iov) {
 						start_addrs = buf + (nbytes - remain_buffer);
-						data_to_copy = _min(remain_buffer, (int)pkt->iov[g_pkt_index].iov_len);
-						memcpy(start_addrs, pkt->iov[g_pkt_index].iov_base, data_to_copy);
+						data_to_copy = _min(remain_buffer,
+								(int)pkt->iov[g_zero_data.pkt_index].iov_len);
+						memcpy(start_addrs,
+								pkt->iov[g_zero_data.pkt_index].iov_base,
+								data_to_copy);
 						remain_buffer -= data_to_copy;
-						g_pkt_offset += data_to_copy;
-						
-						//Handled buffer is filled
-						if (g_pkt_offset < pkt->iov[g_pkt_index].iov_len)	return nbytes;
+						g_zero_data.pkt_offset += data_to_copy;
 
-						g_pkt_offset = 0;
-						g_pkt_index++;
+						//Handled buffer is filled
+						if (g_zero_data.pkt_offset <
+								pkt->iov[g_zero_data.pkt_index].iov_len)
+							return nbytes;
+
+						g_zero_data.pkt_offset = 0;
+						g_zero_data.pkt_index++;
 					}
-					ret = nbytes-remain_buffer;	
+					ret = nbytes - remain_buffer;
+				} else {
+					ret = (remain_buffer == nbytes) ?
+							-1 : (nbytes - remain_buffer);
 				}
-				else{
-					ret = (remain_buffer == nbytes) ? -1 : (nbytes - remain_buffer);
-				}
-			}
-			else {
+			} else {
 				data_to_copy = _min(remain_buffer, ret);
-				memcpy(buf + (nbytes - remain_buffer), g_pkt_buf, data_to_copy);
+				memcpy(buf + (nbytes - remain_buffer), g_zero_data.pkt_buf,
+						data_to_copy);
 				ret = nbytes - (remain_buffer - data_to_copy);
 			}
 		}
 		// Non_blocked with held packet.
 		else if (ret < 0 && os_err_eagain() && (remain_buffer < nbytes)) {
-			return nbytes-remain_buffer;
+			return nbytes - remain_buffer;
 		}
-	}	
-	else
+	} else
 #endif
 	{
 		/*

--- a/src/os_abstract.h
+++ b/src/os_abstract.h
@@ -92,7 +92,8 @@ struct itimerval
   };
 
 void* win_set_timer(void *p_timer);
-
+#define SP_FORCE_INLINE	__forceinline
+#define THREAD_LOCAL	__declspec(thread)
 #else
 
 /***********************************************************************************
@@ -110,7 +111,7 @@ void* win_set_timer(void *p_timer);
 #include <netinet/in.h>
 
 #define INVALID_SOCKET (-1)
-
+#define THREAD_LOCAL __thread
 
 
 /***********************************************************************************
@@ -136,7 +137,7 @@ void* win_set_timer(void *p_timer);
 #include <unistd.h>
 #include <sys/syscall.h>
 #include <endian.h>
-
+#define SP_FORCE_INLINE inline __attribute__ ((always_inline))
 #ifndef htobe64
 #ifdef __USE_BSD
 /* Conversion interfaces.  */


### PR DESCRIPTION
sockperf used a global variable to call free_packet API.
This casued double free in VMA buffers and caused VMA to crash.
This fix changes the globals to be thread locals.

Signed-off-by: Rafi Wiener <rafiw@mellanox.com>