### PR TITLE
fix multithread zero copy crash

### DIFF
--- a/src/Defs.cpp
+++ b/src/Defs.cpp
@@ -42,12 +42,27 @@ TicksTime g_cycleStartTime;
 debug_level_t g_debug_level = LOG_LVL_INFO;
 
 #ifdef  USING_VMA_EXTRA_API
-unsigned char* g_pkt_buf = NULL;
-struct vma_packets_t* g_pkts = NULL;
-unsigned int g_pkt_index = 0;
-unsigned int g_pkt_offset = 0;
 struct vma_buff_t* g_vma_poll_buff = NULL;
 struct vma_completion_t* g_vma_comps;
+
+ZeroCopyData::ZeroCopyData():
+		m_pkt_buf(NULL),
+		m_pkts(NULL),
+		m_pkt_index(0),
+		m_pkt_offset(0) {
+
+};
+
+void ZeroCopyData::allocate() {
+	m_pkt_buf = (unsigned char *)MALLOC(Message::getMaxSize());
+}
+
+ZeroCopyData::~ZeroCopyData() {
+	if (m_pkt_buf)
+		FREE(m_pkt_buf);
+}
+
+zeroCopyMap g_zeroCopyData;
 #endif
 
 

--- a/src/Defs.h
+++ b/src/Defs.h
@@ -90,6 +90,7 @@ typedef uint16_t in_port_t;
 #include <fcntl.h>
 #include <sys/types.h>		/* sockets*/
 #include <queue>
+#include <map>
 
 #include "Ticks.h"
 #include "Message.h"
@@ -392,13 +393,24 @@ extern TicksTime g_cycleStartTime;
 
 extern debug_level_t g_debug_level;
 
-#ifdef  USING_VMA_EXTRA_API
-extern unsigned char* g_pkt_buf;
-extern struct vma_packets_t* g_pkts;
-extern unsigned int g_pkt_index;
-extern unsigned int g_pkt_offset;
+#ifdef USING_VMA_EXTRA_API
+
 extern struct vma_buff_t* g_vma_poll_buff;
 extern struct vma_completion_t* g_vma_comps;
+
+class ZeroCopyData {
+public:
+	ZeroCopyData();
+	void allocate();
+	~ZeroCopyData();
+	unsigned char* m_pkt_buf;
+	struct vma_packets_t* m_pkts;
+	unsigned int m_pkt_index;
+	unsigned int m_pkt_offset;
+};
+// map from fd to zeroCopyData
+typedef std::map<int, ZeroCopyData *> zeroCopyMap;
+extern zeroCopyMap g_zeroCopyData;
 #endif
 
 class Message;

--- a/src/Server.h
+++ b/src/Server.h
@@ -124,11 +124,13 @@ void close_ifd(int fd,int ifd,fds_data* l_fds_ifd){
 	fds_data* l_next_fd =  g_fds_array[fd];
 
 #ifdef  USING_VMA_EXTRA_API
-	if (g_pkts) {
-		g_vma_api->free_packets(fd, g_pkts->pkts, g_pkts->n_packet_num);
-		g_pkts = NULL;
-		g_pkt_index = 0;
-		g_pkt_offset = 0;
+	ZeroCopyData *z_ptr = g_zeroCopyData[fd];
+	if (z_ptr && z_ptr->m_pkts) {
+		g_vma_api->free_packets(fd, z_ptr->m_pkts->pkts,
+				z_ptr->m_pkts->n_packet_num);
+		z_ptr->m_pkts = NULL;
+		z_ptr->m_pkt_index = 0;
+		z_ptr->m_pkt_offset = 0;
 	}
 
 	if (g_vma_api) {


### PR DESCRIPTION
sockperf uses a global variable to call free_packet API.
This casued double free in VMA buffers and caused VMA to crash.
This fix adds a map from fd to it zero zopy data to prevent that.

Signed-off-by: Rafi Wiener <rafiw@mellanox.com>