### PR TITLE
issue: 1308155 Enhance full-log output

### DIFF
--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -92,11 +92,12 @@ void dumpFullLog(int serverNo, RecordLog* pFullLog, size_t size, TicksDuration *
 	if (!f || !size) return;
 
 	fprintf(f, "------------------------------\n");
-	fprintf(f, "txTime, rxTime\n");
+	fprintf(f, "packet, txTime(sec), rxTime(sec), latency(usec)\n");
 	for (size_t i = 0; i < size; i++) {
 		double tx = (double)pFullLog[i][0].debugToNsec()/1000/1000/1000;
 		double rx = (double)pFullLog[i][1].debugToNsec()/1000/1000/1000;
-		fprintf(f, "%.9lf, %.9lf\n", tx, rx);
+		double latency = (rx - tx) * (USEC_PER_SEC / 2);
+		fprintf(f, "%zu, %.9lf, %.9lf, %.3lf\n", i, tx, rx, latency);
 	}
 	fprintf(f, "------------------------------\n");
 }


### PR DESCRIPTION
Current full log output presents only rx and tx timestamps.
This commit will add to the output the packet number and the latency:

packet, txTime(sec), rxTime(sec), latency(usec)
0, 2.615659259, 2.615661049, 0.895
1, 2.615661071, 2.615662848, 0.889
2, 2.615662870, 2.615664693, 0.912
3, 2.615664718, 2.615666514, 0.898

Signed-off-by: Liran Oz <lirano@mellanox.com>