### PR TITLE
issue: 1499649 Add round-trip-time (rtt) support

### DIFF
--- a/src/defs.h
+++ b/src/defs.h
@@ -216,8 +216,11 @@ enum {
     OPT_MC_SOURCE_IP,             // 40
     OPT_DUMMY_SEND,               // 41
     OPT_RATE_LIMIT,               // 42
-    OPT_UC_REUSEADDR              // 43
+    OPT_UC_REUSEADDR,             // 43
+    OPT_FULL_RTT                  // 44
 };
+
+static const char *const round_trip_str[] = { "latency", "rtt" };
 
 #define MODULE_NAME "sockperf"
 #define MODULE_COPYRIGHT                                                                           \
@@ -651,6 +654,7 @@ struct user_params_t {
     char sender_affinity[MAX_ARGV_SIZE];
     char receiver_affinity[MAX_ARGV_SIZE];
     FILE *fileFullLog;               // client side only
+    bool full_rtt;                   // client side only
     bool giga_size;                  // client side only
     bool increase_output_precision;  // client side only
     bool b_stream;                   // client side only

--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -297,6 +297,9 @@ static const AOPT_DESC client_opt_desc[] = {
       aopt_set_literal(0),
       aopt_set_string("full-log"),
       "Dump full log of all messages send/receive time to the given file in CSV format." },
+    { OPT_FULL_RTT,                                         AOPT_NOARG,
+      aopt_set_literal(0),                                  aopt_set_string("full-rtt"),
+      "Show results in round-trip-time instead of latency." },
     { OPT_GIGA_SIZE,                AOPT_NOARG,                aopt_set_literal(0),
       aopt_set_string("giga-size"), "Print sizes in GigaByte." },
     { OPT_OUTPUT_PRECISION,
@@ -1992,6 +1995,9 @@ static int parse_client_opt(const AOPT_OBJECT *client_obj) {
                 rc = SOCKPERF_ERR_BAD_ARGUMENT;
             }
         }
+        if (!rc && aopt_check(client_obj, OPT_FULL_RTT)) {
+            s_user_params.full_rtt = true;
+        }
         if (!rc && aopt_check(client_obj, OPT_GIGA_SIZE)) {
             s_user_params.giga_size = true;
         }
@@ -2198,6 +2204,7 @@ void set_defaults() {
     // s_user_params.b_load_vma = false;
     s_user_params.fileFullLog = NULL;
     s_user_params.b_stream = false;
+    s_user_params.full_rtt = false;
     s_user_params.giga_size = false;
     s_user_params.increase_output_precision = false;
     s_user_params.pPlaybackVector = NULL;


### PR DESCRIPTION
Using the new RTT pararmter, the output results can be
printed in RTT units instead of latency.
rtt option is valid only for the client side.
Usage - sockperf <sockperf params> --rtt

Signed-off-by: Liran Oz <lirano@mellanox.com>