### PR TITLE
issue: 1508288 Fix expected max packet seqno calculation

### DIFF
--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -3161,8 +3161,23 @@ int bringup(const int *p_daemonize) {
             s_user_params.dummySendCycleDuration = TicksDuration(dummySendCycleDurationNsec);
         }
 
+        s_user_params.warmup_msec = TEST_FIRST_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC +
+                                    s_fd_num * TEST_ANY_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC;
+        if (s_user_params.warmup_msec < TEST_START_WARMUP_MSEC) {
+            s_user_params.warmup_msec = TEST_START_WARMUP_MSEC;
+        } else {
+            log_dbg(
+                "Warm-up set in relation to number of active connections. Warm up time: %" PRIu32
+                " usec; first connection's first packet TTL: %d usec; following connections' first "
+                "packet TTL: %d usec\n",
+                g_pApp->m_const_params.warmup_msec,
+                TEST_FIRST_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC * 1000,
+                (int)(TEST_ANY_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC * 1000));
+        }
+
         uint64_t _maxTestDuration =
-            1 + s_user_params.sec_test_duration; // + 1sec for timer inaccuracy safety
+            1 + s_user_params.sec_test_duration +
+            s_user_params.warmup_msec / 1000; // + 1sec for timer inaccuracy safety
         uint64_t _maxSequenceNo = _maxTestDuration * s_user_params.mps +
                                   10 * s_user_params.reply_every; // + 10 replies for safety
         _maxSequenceNo += s_user_params.burst_size; // needed for the case burst_size > mps
@@ -3182,20 +3197,6 @@ int bringup(const int *p_daemonize) {
         if (!s_user_params.b_stream && (!s_user_params.mode) == MODE_SERVER) {
             g_pPacketTimes = new PacketTimes(_maxSequenceNo, s_user_params.reply_every,
                                              s_user_params.client_work_with_srv_num);
-        }
-
-        s_user_params.warmup_msec = TEST_FIRST_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC +
-                                    s_fd_num * TEST_ANY_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC;
-        if (s_user_params.warmup_msec < TEST_START_WARMUP_MSEC) {
-            s_user_params.warmup_msec = TEST_START_WARMUP_MSEC;
-        } else {
-            log_dbg(
-                "Warm-up set in relation to number of active connections. Warm up time: %" PRIu32
-                " usec; first connection's first packet TTL: %d usec; following connections' first "
-                "packet TTL: %d usec\n",
-                g_pApp->m_const_params.warmup_msec,
-                TEST_FIRST_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC * 1000,
-                (int)(TEST_ANY_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC * 1000));
         }
 
         os_set_signal_action(SIGINT, s_user_params.mode ? server_sig_handler : client_sig_handler);


### PR DESCRIPTION
Expected max packet sequence number should take in consideration the
warm up time in addition to the total test duration.

Signed-off-by: Liran Oz <lirano@mellanox.com>