### PR TITLE
socketxtreme cleanup in msg recv

### DIFF
--- a/src/client.h
+++ b/src/client.h
@@ -163,7 +163,7 @@ private:
 #endif
         {
             ret = msg_recvfrom(ifd, l_fds_ifd->recv.cur_addr + l_fds_ifd->recv.cur_offset,
-                               l_fds_ifd->recv.cur_size, &recvfrom_addr);
+                               l_fds_ifd->recv.cur_size, &recvfrom_addr, &l_fds_ifd->recv.cur_addr);
         }
         if (unlikely(ret <= 0)) {
             if (ret == RET_SOCKET_SHUTDOWN) {

--- a/src/client.h
+++ b/src/client.h
@@ -141,6 +141,7 @@ private:
         struct sockaddr_in recvfrom_addr;
         int receiveCount = 0;
         int serverNo = 0;
+        int remain_buffer = 0;
         fds_data *l_fds_ifd = g_fds_array[ifd];
 
         TicksTime rxTime;
@@ -159,11 +160,16 @@ private:
                 l_fds_ifd->recv.cur_offset = 0;
             }
             ret = tmp_vma_buff->len;
+        } else if (g_pApp->m_const_params.is_vmazcopyread &&
+                   !(remain_buffer = free_vma_packets(ifd, l_fds_ifd->recv.cur_size))) {
+            // Handled buffer is filled, free_vma_packets returns 0
+            ret = l_fds_ifd->recv.cur_size;
         } else
 #endif
         {
             ret = msg_recvfrom(ifd, l_fds_ifd->recv.cur_addr + l_fds_ifd->recv.cur_offset,
-                               l_fds_ifd->recv.cur_size, &recvfrom_addr, &l_fds_ifd->recv.cur_addr);
+                               l_fds_ifd->recv.cur_size, &recvfrom_addr, &l_fds_ifd->recv.cur_addr,
+                               remain_buffer);
         }
         if (unlikely(ret <= 0)) {
             if (ret == RET_SOCKET_SHUTDOWN) {

--- a/src/defs.h
+++ b/src/defs.h
@@ -323,17 +323,17 @@ typedef enum {
 
 inline void log_send(const char *name, int priority, const char *file_name, const int line_no,
                      const char *func_name, const char *format, ...) {
-    char buf[250];
-    va_list va;
-    int n = 0;
-
     if (priority) {
+        char buf[250];
+        va_list va;
+        int n = 0;
+
         va_start(va, format);
         n = vsnprintf(buf, sizeof(buf) - 1, format, va);
         va_end(va);
 
-        printf("[%s] %s: %s <%s: %s #%d>\n", "debug", (name ? name : ""), buf, file_name, func_name,
-               line_no);
+        printf("[%s] %s: %s <%s: %s #%d> size %d\n", "debug", (name ? name : ""), buf, file_name,
+               func_name, line_no, n);
     }
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -185,7 +185,7 @@ inline bool Server<IoType, SwitchActivityInfo, SwitchCalcGaps>::server_receive_t
 #endif
     {
         ret = msg_recvfrom(ifd, l_fds_ifd->recv.cur_addr + l_fds_ifd->recv.cur_offset,
-                           l_fds_ifd->recv.cur_size, &recvfrom_addr);
+                           l_fds_ifd->recv.cur_size, &recvfrom_addr, &l_fds_ifd->recv.cur_addr);
     }
     if (unlikely(ret <= 0)) {
         if (ret == RET_SOCKET_SHUTDOWN) {

--- a/src/server.h
+++ b/src/server.h
@@ -170,18 +170,7 @@ inline bool Server<IoType, SwitchActivityInfo, SwitchCalcGaps>::server_receive_t
 #ifdef USING_VMA_EXTRA_API
     vma_buff_t *tmp_vma_buff = g_vma_buff;
     if (SOCKETXTREME == g_pApp->m_const_params.fd_handler_type && tmp_vma_buff) {
-        recvfrom_addr = g_vma_comps->src;
-        if (l_fds_ifd->recv.cur_offset) {
-            l_fds_ifd->recv.cur_addr = l_fds_ifd->recv.buf;
-            l_fds_ifd->recv.cur_size = l_fds_ifd->recv.max_size - l_fds_ifd->recv.cur_offset;
-            memmove(l_fds_ifd->recv.cur_addr + l_fds_ifd->recv.cur_offset,
-                    (uint8_t *)tmp_vma_buff->payload, tmp_vma_buff->len);
-        } else {
-            l_fds_ifd->recv.cur_addr = (uint8_t *)tmp_vma_buff->payload;
-            l_fds_ifd->recv.cur_size = l_fds_ifd->recv.max_size;
-            l_fds_ifd->recv.cur_offset = 0;
-        }
-        ret = tmp_vma_buff->len;
+        ret = msg_recv_socketxtreme(l_fds_ifd, tmp_vma_buff, &recvfrom_addr);
     } else if (g_pApp->m_const_params.is_vmazcopyread &&
                !(remain_buffer = free_vma_packets(ifd, l_fds_ifd->recv.cur_size))) {
         // Handled buffer is filled, free_vma_packets returns 0
@@ -345,24 +334,9 @@ inline bool Server<IoType, SwitchActivityInfo, SwitchCalcGaps>::server_receive_t
 #ifdef USING_VMA_EXTRA_API
     next:
         if (tmp_vma_buff) {
-            if (l_fds_ifd->recv.cur_offset) {
-                memmove(l_fds_ifd->recv.buf, l_fds_ifd->recv.cur_addr, l_fds_ifd->recv.cur_offset);
-                l_fds_ifd->recv.cur_addr = l_fds_ifd->recv.buf;
-                l_fds_ifd->recv.cur_size = l_fds_ifd->recv.max_size - l_fds_ifd->recv.cur_offset;
-                if (tmp_vma_buff->next) {
-                    tmp_vma_buff = tmp_vma_buff->next;
-                    memmove(l_fds_ifd->recv.cur_addr + l_fds_ifd->recv.cur_offset,
-                            (uint8_t *)tmp_vma_buff->payload, tmp_vma_buff->len);
-                    nbytes = tmp_vma_buff->len;
-                } else {
-                    return (!do_update);
-                }
-            } else if (0 == nbytes && tmp_vma_buff->next) {
-                tmp_vma_buff = tmp_vma_buff->next;
-                l_fds_ifd->recv.cur_addr = (uint8_t *)tmp_vma_buff->payload;
-                l_fds_ifd->recv.cur_size = l_fds_ifd->recv.max_size;
-                l_fds_ifd->recv.cur_offset = 0;
-                nbytes = tmp_vma_buff->len;
+            ret = msg_process_next(l_fds_ifd, &tmp_vma_buff, &nbytes);
+            if (ret) {
+                return (!do_update);
             }
         }
 #endif


### PR DESCRIPTION
Remove duplicated socketxtreme code in msg recv from server.h and client.h, and add the common code to common.h