### PR TITLE
issue: 1380243 Fix close SocketXtreme established TCP sockets

### DIFF
--- a/src/iohandlers.h
+++ b/src/iohandlers.h
@@ -468,6 +468,8 @@ public:
         } else if (g_vma_comps->events & VMA_SOCKETXTREME_PACKET) {
             g_vma_buff = g_vma_comps->packet.buff_lst;
             ifd = g_vma_comps->user_data;
+        } else if (g_vma_comps->events & (EPOLLIN | EPOLLERR | EPOLLHUP | EPOLLRDHUP)) {
+            ifd = g_vma_comps->user_data;
         } else {
             ifd = 0;
         }


### PR DESCRIPTION
Handle close segment for SocketXtreme to close established TCP sockets.

Signed-off-by: Mohammad Qurt <mohammadq@mellanox.com>