### PR TITLE
issue: 1801987 Fix segfault with an empty feed file

### DIFF
--- a/src/aopt.cpp
+++ b/src/aopt.cpp
@@ -33,6 +33,7 @@
 #include "os_abstract.h"
 
 #include "aopt.h"
+#include "defs.h"
 
 #define _AOPT_CONF_TRACE TRUE
 
@@ -81,7 +82,7 @@ const AOPT_OBJECT *aopt_init(int *argc, const char **argv, const AOPT_DESC *desc
             }
         }
         if (opt_count) {
-            arg_obj = (AOPT_OBJECT *)malloc((opt_count + 1) * sizeof(AOPT_OBJECT));
+            arg_obj = (AOPT_OBJECT *)MALLOC((opt_count + 1) * sizeof(AOPT_OBJECT));
             memset(arg_obj, 0, (opt_count + 1) * sizeof(AOPT_OBJECT));
         }
     }
@@ -319,7 +320,7 @@ const char *aopt_help(const AOPT_DESC *desc) {
         char *buf_temp = NULL;
         int ret = 0;
 
-        buf = (char *)malloc(buf_size);
+        buf = (char *)MALLOC(buf_size);
         memset(buf, 0, buf_size);
 
         for (; desc && desc->key && buf; desc++) {
@@ -398,7 +399,7 @@ const char *aopt_help(const AOPT_DESC *desc) {
                     buf_size *= 2;
 
                 buf_temp = buf;
-                buf = (char *)malloc(buf_size);
+                buf = (char *)MALLOC(buf_size);
                 memset(buf, 0, buf_size);
                 memcpy(buf, buf_temp, buf_offset);
                 free(buf_temp);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -252,7 +252,7 @@ int Server<IoType, SwitchActivityInfo, SwitchCalcGaps>::server_accept(int ifd) {
             return (int)INVALID_SOCKET; // TODO: use SOCKET all over the way and avoid this cast
         }
         memcpy(tmp, g_fds_array[ifd], sizeof(struct fds_data));
-        tmp->recv.buf = (uint8_t *)malloc(sizeof(uint8_t) * 2 * MAX_PAYLOAD_SIZE);
+        tmp->recv.buf = (uint8_t *)MALLOC(sizeof(uint8_t) * 2 * MAX_PAYLOAD_SIZE);
         if (!tmp->recv.buf) {
             log_err("Failed to allocate memory with malloc()");
             FREE(tmp);

--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -2921,7 +2921,7 @@ static int set_sockets_from_feedfile(const char *feedfile_name) {
                         // TODO: In the following malloc we have a one time memory allocation of
                         // 128KB that are not reclaimed
                         // This O(1) leak was introduced in revision 133
-                        tmp->recv.buf = (uint8_t *)malloc(sizeof(uint8_t) * 2 * MAX_PAYLOAD_SIZE);
+                        tmp->recv.buf = (uint8_t *)MALLOC(sizeof(uint8_t) * 2 * MAX_PAYLOAD_SIZE);
                         if (!tmp->recv.buf) {
                             log_err("Failed to allocate memory with malloc()");
                             FREE(tmp);
@@ -3116,7 +3116,7 @@ int bringup(const int *p_daemonize) {
                                 tmp->active_fd_list[i] = (int)INVALID_SOCKET;
                             }
                             tmp->recv.buf =
-                                (uint8_t *)malloc(sizeof(uint8_t) * 2 * MAX_PAYLOAD_SIZE);
+                                (uint8_t *)MALLOC(sizeof(uint8_t) * 2 * MAX_PAYLOAD_SIZE);
                             if (!tmp->recv.buf) {
                                 log_err("Failed to allocate memory with malloc()");
                                 FREE(tmp);


### PR DESCRIPTION
Socket objects are linked into a cyclic linked list. The operation
of looping the list leads to a NULL pointer dereference if the list
is empty.

Don't loop the list if number of the socket objects equals to 0.
This is a special case that happens when an empty feed file is
provided. Fall back to creating a single default socket object for
the case.