### PR TITLE
Add sanity check for the sockets list

### DIFF
--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -3014,6 +3014,30 @@ static int set_sockets_from_feedfile(const char *feedfile_name) {
 }
 
 //------------------------------------------------------------------------------
+/* Sanity check for the sockets list inside g_fds_array. */
+static bool fds_array_is_valid()
+{
+    int i;
+    int fd;
+
+    /*
+     * This function checks that s_fd_max is reachable from s_fd_min in exactly
+     * s_fd_num steps. Additionally, s_fd_max's list element must point to
+     * s_fd_min.
+     * Note, the function doesn't require the list to be sorted.
+     */
+
+    for (fd = s_fd_min, i = 0; i < s_fd_num && fd != s_fd_max; ++i) {
+        if (g_fds_array[fd] == NULL)
+            return false;
+        fd = g_fds_array[fd]->next_fd;
+    }
+    return fd == s_fd_max &&
+           (i + 1) == s_fd_num &&
+           g_fds_array[fd]->next_fd == s_fd_min;
+}
+
+//------------------------------------------------------------------------------
 int bringup(const int *p_daemonize) {
     int rc = SOCKPERF_ERR_NONE;
 
@@ -3144,6 +3168,11 @@ int bringup(const int *p_daemonize) {
                     FREE(tmp);
                 }
             }
+        }
+
+        if (!rc && !fds_array_is_valid()) {
+            log_err("Sanity check failed for sockets list");
+            rc = SOCKPERF_ERR_FATAL;
         }
 
         if (!rc && (s_user_params.threads_num > s_fd_num || s_user_params.threads_num == 0)) {


### PR DESCRIPTION
Additionally to flat array of sockets file descriptors, sockperf links
the sockets into a cyclic linked list. Wrapping the list is done as
linking the maximum socket number with the minimum one.

The algorithms works while OS allocates file descriptors in an increasing
order. If fd was allocated out of the order the algorithm would possibly
produce an invalid list, for example:
```
 4 -> 3 -> 6 -+  5
      ^       |
      +-------+
```

Such a scenario can happen if a thread opens and closes fds concurrently
with sockperf. This is achieved through LD_PRELOAD.

Add sanity check for the cyclic list and report an error instead of
processing an invalid list.
