### PR TITLE
issue: 2009935 Fix m_maxSequenceNo calculation

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -54,9 +54,11 @@ void print_average_results(double usecAvarage) {
 /* set the timer on client to the [-t sec] parameter given by user */
 void set_client_timer(struct itimerval *timer) {
     // extra sec and extra msec will be excluded from results
-    timer->it_value.tv_sec = (TEST_END_COOLDOWN_MSEC + g_pApp->m_const_params.warmup_msec) / 1000 +
-                             g_pApp->m_const_params.sec_test_duration;
-    timer->it_value.tv_usec = (TEST_END_COOLDOWN_MSEC + g_pApp->m_const_params.warmup_msec) % 1000;
+    timer->it_value.tv_sec =
+        (g_pApp->m_const_params.cooldown_msec + g_pApp->m_const_params.warmup_msec) / 1000 +
+        g_pApp->m_const_params.sec_test_duration;
+    timer->it_value.tv_usec =
+        (g_pApp->m_const_params.cooldown_msec + g_pApp->m_const_params.warmup_msec) % 1000;
     timer->it_interval.tv_sec = 0;
     timer->it_interval.tv_usec = 0;
 }

--- a/src/defs.h
+++ b/src/defs.h
@@ -636,6 +636,7 @@ struct user_params_t {
     bool is_blocked;
     bool do_warmup;
     unsigned int pre_warmup_wait;
+    uint32_t cooldown_msec;
     uint32_t warmup_msec;
     bool is_vmarxfiltercb;
     bool is_vmazcopyread;

--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -3175,6 +3175,7 @@ int bringup(const int *p_daemonize) {
             s_user_params.dummySendCycleDuration = TicksDuration(dummySendCycleDurationNsec);
         }
 
+        s_user_params.cooldown_msec = TEST_END_COOLDOWN_MSEC;
         s_user_params.warmup_msec = TEST_FIRST_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC +
                                     s_fd_num * TEST_ANY_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC;
         if (s_user_params.warmup_msec < TEST_START_WARMUP_MSEC) {
@@ -3189,9 +3190,9 @@ int bringup(const int *p_daemonize) {
                 (int)(TEST_ANY_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC * 1000));
         }
 
-        uint64_t _maxTestDuration =
-            1 + s_user_params.sec_test_duration +
-            s_user_params.warmup_msec / 1000; // + 1sec for timer inaccuracy safety
+        uint64_t _maxTestDuration = 1 + s_user_params.sec_test_duration +
+                                    (s_user_params.warmup_msec + s_user_params.cooldown_msec) /
+                                        1000; // + 1sec for timer inaccuracy safety
         uint64_t _maxSequenceNo = _maxTestDuration * s_user_params.mps +
                                   10 * s_user_params.reply_every; // + 10 replies for safety
         _maxSequenceNo += s_user_params.burst_size; // needed for the case burst_size > mps

--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -540,7 +540,7 @@ static int proc_mode_under_load(int id, int argc, const char **argv) {
             int len;
             const char *optarg = aopt_value(self_obj, OPT_CLIENTIP);
             if (!optarg) { /* already in network byte order*/
-                log_msg("'-%c' Invalid address: %s", OPT_CLIENTIP, optarg);
+                log_msg("'-%c' Invalid address", OPT_CLIENTIP);
                 rc = SOCKPERF_ERR_BAD_ARGUMENT;
             } else if (4 != sscanf(optarg, "%d.%d.%d.%d", &len, &len, &len, &len)) {
                 log_msg("'-%c' Invalid address: %s", OPT_CLIENTIP, optarg);
@@ -805,7 +805,7 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
             int len;
             const char *optarg = aopt_value(self_obj, OPT_CLIENTIP);
             if (!optarg) { /* already in network byte order*/
-                log_msg("'-%c' Invalid address: %s", OPT_CLIENTIP, optarg);
+                log_msg("'-%c' Invalid address", OPT_CLIENTIP);
                 rc = SOCKPERF_ERR_BAD_ARGUMENT;
             } else if (4 != sscanf(optarg, "%d.%d.%d.%d", &len, &len, &len, &len)) {
                 log_msg("'-%c' Invalid address: %s", OPT_CLIENTIP, optarg);
@@ -1082,7 +1082,7 @@ static int proc_mode_throughput(int id, int argc, const char **argv) {
             int len;
             const char *optarg = aopt_value(self_obj, OPT_CLIENTIP);
             if (!optarg) { /* already in network byte order*/
-                log_msg("'-%c' Invalid address: %s", OPT_CLIENTIP, optarg);
+                log_msg("'-%c' Invalid address", OPT_CLIENTIP);
                 rc = SOCKPERF_ERR_BAD_ARGUMENT;
             } else if (4 != sscanf(optarg, "%d.%d.%d.%d", &len, &len, &len, &len)) {
                 log_msg("'-%c' Invalid address: %s", OPT_CLIENTIP, optarg);
@@ -1530,7 +1530,7 @@ static int parse_common_opt(const AOPT_OBJECT *common_obj) {
             const char *optarg = aopt_value(common_obj, 'i');
             int len;
             if (!optarg) { /* already in network byte order*/
-                log_msg("'-%c' Invalid address: %s", 'i', optarg);
+                log_msg("'-%c' Invalid address", 'i');
                 rc = SOCKPERF_ERR_BAD_ARGUMENT;
             } else if (4 != sscanf(optarg, "%d.%d.%d.%d", &len, &len, &len, &len)) {
                 log_msg("'-%c' Invalid address: %s", 'i', optarg);
@@ -2935,25 +2935,25 @@ static int set_sockets_from_feedfile(const char *feedfile_name) {
                         tmp->recv.buf = (uint8_t *)malloc(sizeof(uint8_t) * 2 * MAX_PAYLOAD_SIZE);
                         if (!tmp->recv.buf) {
                             log_err("Failed to allocate memory with malloc()");
-                            FREE(tmp);
                             rc = SOCKPERF_ERR_NO_MEMORY;
-                        }
-                        tmp->recv.cur_addr = tmp->recv.buf;
-                        tmp->recv.max_size = MAX_PAYLOAD_SIZE;
-                        tmp->recv.cur_offset = 0;
-                        tmp->recv.cur_size = tmp->recv.max_size;
+                        } else {
+                            tmp->recv.cur_addr = tmp->recv.buf;
+                            tmp->recv.max_size = MAX_PAYLOAD_SIZE;
+                            tmp->recv.cur_offset = 0;
+                            tmp->recv.cur_size = tmp->recv.max_size;
 
-                        if (new_socket_flag) {
-                            if (s_fd_num == 1) { /*it is the first fd*/
-                                s_fd_min = curr_fd;
-                                s_fd_max = curr_fd;
-                            } else {
-                                g_fds_array[last_fd]->next_fd = curr_fd;
-                                s_fd_min = _min(s_fd_min, curr_fd);
-                                s_fd_max = _max(s_fd_max, curr_fd);
+                            if (new_socket_flag) {
+                                if (s_fd_num == 1) { /*it is the first fd*/
+                                    s_fd_min = curr_fd;
+                                    s_fd_max = curr_fd;
+                                } else {
+                                    g_fds_array[last_fd]->next_fd = curr_fd;
+                                    s_fd_min = _min(s_fd_min, curr_fd);
+                                    s_fd_max = _max(s_fd_max, curr_fd);
+                                }
+                                last_fd = curr_fd;
+                                g_fds_array[curr_fd] = tmp;
                             }
-                            last_fd = curr_fd;
-                            g_fds_array[curr_fd] = tmp;
                         }
                     }
                 }
@@ -3118,17 +3118,17 @@ int bringup(const int *p_daemonize) {
                                 (uint8_t *)malloc(sizeof(uint8_t) * 2 * MAX_PAYLOAD_SIZE);
                             if (!tmp->recv.buf) {
                                 log_err("Failed to allocate memory with malloc()");
-                                FREE(tmp);
                                 rc = SOCKPERF_ERR_NO_MEMORY;
-                            }
-                            tmp->recv.cur_addr = tmp->recv.buf;
-                            tmp->recv.max_size = MAX_PAYLOAD_SIZE;
-                            tmp->recv.cur_offset = 0;
-                            tmp->recv.cur_size = tmp->recv.max_size;
+                            } else {
+                                tmp->recv.cur_addr = tmp->recv.buf;
+                                tmp->recv.max_size = MAX_PAYLOAD_SIZE;
+                                tmp->recv.cur_offset = 0;
+                                tmp->recv.cur_size = tmp->recv.max_size;
 
-                            s_fd_min = s_fd_max = curr_fd;
-                            g_fds_array[s_fd_min] = tmp;
-                            g_fds_array[s_fd_min]->next_fd = s_fd_min;
+                                s_fd_min = s_fd_max = curr_fd;
+                                g_fds_array[s_fd_min] = tmp;
+                                g_fds_array[s_fd_min]->next_fd = s_fd_min;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
The reason of it is a problem is that the calculation for the
Max Sequence Number (_maxSequenceNo) is based off of _maxTestDuration,
and it currently accounts for only the messages sent during
the sum of the "Warm up time" and the "Valid Duration" time,
but not for messages sent during the cooldown time.

Signed-off-by: Igor Ivanov <igor.ivanov.va@gmail.com>