### PR TITLE
issue: 2597798 Add observation based measurement, more stats, and histogram

### DIFF
--- a/src/aopt.cpp
+++ b/src/aopt.cpp
@@ -298,6 +298,59 @@ const char *aopt_value(const AOPT_OBJECT *aopt_obj, int key) {
 }
 
 /**
+ * aopt_get_desc
+ *
+ * @brief
+ *    Return AOPT Description struct of option selected via key.
+ *
+ * @param[in]    desc           Option description.
+ * @param[in]    key            Option key.
+ *
+ * @retval pointer to description struct - on success
+ * @retval NULL - on failure
+ ***************************************************************************/
+const AOPT_DESC *aopt_get_desc(const AOPT_DESC *aopt_desc, int key) {
+    if (key == 0) {
+        log_err("Not a valid key for aopt");
+        return NULL;
+    }
+
+    const AOPT_DESC *desc = NULL;
+    int i = 0;
+
+    while(aopt_desc[i].key != 0) {
+        if(aopt_desc[i].key == key) {
+            desc = &aopt_desc[i];
+            break;
+        }
+        i++;
+    }
+
+    return desc;
+}
+
+/**
+ * aopt_get_long_name
+ *
+ * @brief
+ *    Return long name of option description selected via key.
+ *
+ * @param[in]    desc           Option description.
+ * @param[in]    key            Option key.
+ *
+ * @retval pointer to string - on success
+ * @retval NULL - on failure
+ ***************************************************************************/
+const char *aopt_get_long_name(const AOPT_DESC *aopt_desc, int key) {
+    if (key == 0) {
+        log_err("Not a valid key for aopt");
+        return NULL;
+    }
+
+    return *aopt_get_desc(aopt_desc, key)->longs;
+}
+
+/**
  * aopt_help
  *
  * @brief

--- a/src/aopt.h
+++ b/src/aopt.h
@@ -161,6 +161,34 @@ int aopt_check(const AOPT_OBJECT *aopt_obj, int key);
 const char *aopt_value(const AOPT_OBJECT *aopt_obj, int key);
 
 /**
+ * aopt_get_desc
+ *
+ * @brief
+ *    Return AOPT Description struct of option selected via key.
+ *
+ * @param[in]    desc           Option description.
+ * @param[in]    key            Option key.
+ *
+ * @retval pointer to description struct - on success
+ * @retval NULL - on failure
+ ***************************************************************************/
+const AOPT_DESC *aopt_get_desc(const AOPT_DESC *aopt_desc, int key);
+
+/**
+ * aopt_get_long_name
+ *
+ * @brief
+ *    Return long name of option description selected via key.
+ *
+ * @param[in]    desc           Option description.
+ * @param[in]    key            Option key.
+ *
+ * @retval pointer to string - on success
+ * @retval NULL - on failure
+ ***************************************************************************/
+const char *aopt_get_long_name(const AOPT_DESC *aopt_desc, int key);
+
+/**
  * aopt_help
  *
  * @brief

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -33,6 +33,8 @@
 #include "packet.h"
 #include "switches.h"
 
+#include <math.h>
+
 TicksTime s_startTime, s_endTime;
 
 //==============================================================================
@@ -66,7 +68,7 @@ void set_client_timer(struct itimerval *timer) {
 //------------------------------------------------------------------------------
 /*  set the timer on client to limit waiting based on [-n number-of-observations] parameter given by
     user and sampling data */
-void set_client_time_out_timer(struct itimerval *timer, TicksTime testStart) {
+void set_client_observation_timer(struct itimerval *timer, TicksTime testStart) {
     /*  Based off observation rate during sampling, estimate total run time.
         Using warmup as our sample includes a bias for higher latency, because the head of
         the test has less load and receiver has no recent cache. This works to our benefit
@@ -94,10 +96,8 @@ void set_client_time_out_timer(struct itimerval *timer, TicksTime testStart) {
 }
 
 //------------------------------------------------------------------------------
-void printPercentiles(FILE *f, TicksDuration *pLat, size_t size) {
-    qsort(pLat, size, sizeof(TicksDuration), TicksDuration::compare);
-
-    double percentile[] = { 0.99999, 0.9999, 0.999, 0.99, 0.90, 0.75, 0.50, 0.25 };
+void printPercentiles(FILE *f, TicksDuration *sortedpLat, size_t size) {
+    const double percentile[] = { 0.99999, 0.9999, 0.999, 0.99, 0.90, 0.75, 0.50, 0.25 };
     int num = sizeof(percentile) / sizeof(percentile[0]);
     double observationsInPercentile = (double)size / 100;
 
@@ -105,22 +105,22 @@ void printPercentiles(FILE *f, TicksDuration *pLat, size_t size) {
                              "; each percentile contains %.2lf observations",
                   (long unsigned)size, observationsInPercentile);
 
-    log_msg_file2(f, "---> <MAX> observation = %8.3lf", pLat[size - 1].toDecimalUsec());
+    log_msg_file2(f, "---> <MAX> observation = %8.3lf", sortedpLat[size - 1].toDecimalUsec());
     for (int i = 0; i < num; i++) {
         int index = (int)(0.5 + percentile[i] * size) - 1;
         if (index >= 0) {
             log_msg_file2(f, "---> percentile %6.3lf = %8.3lf", 100 * percentile[i],
-                          pLat[index].toDecimalUsec());
+                          sortedpLat[index].toDecimalUsec());
         }
     }
-    log_msg_file2(f, "---> <MIN> observation = %8.3lf", pLat[0].toDecimalUsec());
+    log_msg_file2(f, "---> <MIN> observation = %8.3lf", sortedpLat[0].toDecimalUsec());
 }
 
 //------------------------------------------------------------------------------
 typedef TicksTime RecordLog[2];
 
 //------------------------------------------------------------------------------
-void dumpFullLog(int serverNo, RecordLog *pFullLog, size_t size, TicksDuration *pLat) {
+void dumpFullLog(int serverNo, RecordLog *pFullLog, size_t size) {
     FILE *f = g_pApp->m_const_params.fileFullLog;
     uint32_t denominator = g_pApp->m_const_params.full_rtt ? 1 : 2;
     if (!f || !size) return;
@@ -135,6 +135,36 @@ void dumpFullLog(int serverNo, RecordLog *pFullLog, size_t size, TicksDuration *
         fprintf(f, "%zu, %.9lf, %.9lf, %.3lf\n", i, tx, rx, result);
     }
     fprintf(f, "------------------------------\n");
+}
+
+//------------------------------------------------------------------------------
+double RationalApproximation(double t) {
+    // Abramowitz and Stegun formula 26.2.23
+    // with constants from here: https://arxiv.org/pdf/1002.0567.pdf, Section 3
+    // Absolute value of error should be less than 8 e-5
+    const double c[] = {2.653962002601684482, 1.561533700212080345, 0.061146735765196993};
+    const double d[] = {1.904875182836498708, 0.454055536444233510, 0.009547745327068945};
+    return t - ((c[2]*t + c[1])*t + c[0]) /
+        (((d[2]*t + d[1])*t + d[0])*t + 1.0);
+}
+
+//------------------------------------------------------------------------------
+double NormalCDFInverse(double p) {
+    if (p < 0.0 || p > 1.0) {
+        log_err("NormalCDFInverse only accepts 0 < p < 1");
+        return 0;
+    }
+
+    // Approximation function is only valid for (0 < p < .5)
+    // Extend to (0 < p < 1) by taking advantage of normal CDF inverse odd symmetry shape
+    // Detailed explanation here: https://www.johndcook.com/blog/normal_cdf_inverse/#basic
+    if (p < 0.5) {
+        // F^-1(p) = - G^-1(p)
+        return -RationalApproximation( sqrt(-2.0*log(p)) );
+    } else {
+        // F^-1(p) = G^-1(1-p)
+        return RationalApproximation( sqrt(-2.0*log(1-p)) );
+    }
 }
 
 //------------------------------------------------------------------------------
@@ -303,17 +333,30 @@ void client_statistics(int serverNo, Message *pMsgRequest) {
                       validRunTime.toDecimalUsec() / 1000000, (endValidSeqNo - startValidSeqNo + 1),
                       (uint64_t)counter);
 
+        TicksDuration::sort(pLat, counter);
+        TicksDuration *sortedpLat = &pLat[0]; // alias for pLat after being sorted
         TicksDuration avgRtt = counter ? sumRtt / (int)counter : TicksDuration::TICKS0;
         TicksDuration avgLatency = avgRtt / 2;
-        double usecAvarage =
-            g_pApp->m_const_params.full_rtt ? avgRtt.toDecimalUsec() : avgLatency.toDecimalUsec();
-
         TicksDuration stdDev = TicksDuration::stdDev(pLat, counter);
-        log_msg_file2(f, MAGNETA "====> avg-%s=%.3lf (std-dev=%.3lf)" ENDCOLOR,
-                      round_trip_str[g_pApp->m_const_params.full_rtt], usecAvarage,
-                      stdDev.toDecimalUsec());
+        TicksDuration mad = TicksDuration::mad(pLat, counter);
+        TicksDuration medianad = TicksDuration::medianad(pLat, counter);
+        TicksDuration siqr = TicksDuration::siqr(pLat, counter);
+        double usecAvarage = g_pApp->m_const_params.full_rtt ? avgRtt.toDecimalUsec() : avgLatency.toDecimalUsec();
+        double coefficientOfVariance = stdDev.toDecimalUsec() / usecAvarage;
+        double standardError = stdDev.toDecimalUsec() / sqrt(counter);
+        double significanceLevel = s_user_params.ci_significance_level;
+        double zScore = 1 - (1 - significanceLevel/100) / 2;
+        double confidenceLevelValue = NormalCDFInverse(zScore);
+        double lowerInterval = usecAvarage - confidenceLevelValue * standardError;
+        double upperInterval = usecAvarage + confidenceLevelValue * standardError;
+        log_msg_file2(f, MAGNETA "====> avg-%s=%.3lf (std-dev=%.3lf, mean-ad=%.3lf, median-ad=%.3lf, siqr=%.3lf, "
+            "cv=%.3lf, std-error=%.3lf, %.1lf%% ci=[%.3lf, %.3lf])" ENDCOLOR,
+            round_trip_str[g_pApp->m_const_params.full_rtt], usecAvarage,
+            stdDev.toDecimalUsec(), mad.toDecimalUsec(), medianad.toDecimalUsec(), siqr.toDecimalUsec(),
+            coefficientOfVariance, standardError, significanceLevel, lowerInterval, upperInterval);
 
-        /* Display ERROR statistic */
+        /* Display ERROR statistic*/
+
         bool isColor =
             (g_pPacketTimes->getDroppedCount(SERVER_NO) || g_pPacketTimes->getDupCount(SERVER_NO) ||
              g_pPacketTimes->getOooCount(SERVER_NO));
@@ -327,9 +370,9 @@ void client_statistics(int serverNo, Message *pMsgRequest) {
 
         if (usecAvarage) print_average_results(usecAvarage);
 
-        printPercentiles(f, pLat, counter);
+        printPercentiles(f, sortedpLat, counter);
 
-        dumpFullLog(SERVER_NO, pFullLog, counter, pLat);
+        dumpFullLog(SERVER_NO, pFullLog, counter);
     }
 
     delete[] pLat;
@@ -775,9 +818,9 @@ void Client<IoType, SwitchDataIntegrity, SwitchActivityInfo, SwitchCycleDuration
             prevRxTime = rxTime;
             counterValid++;
 
-            // Set timer to limit waiting on total observations
+            // Set timer to limit waiting on observations based off warmup sample
             if(counterValid == warmupObservations && timer.it_value.tv_sec == 0) {
-                set_client_time_out_timer(&timer, testStart);
+                set_client_observation_timer(&timer, testStart);
                 if (os_set_duration_timer(timer, client_sig_handler)) {
                     exit_with_log("Failed setting test observation timer", SOCKPERF_ERR_FATAL);
                 }
@@ -785,6 +828,12 @@ void Client<IoType, SwitchDataIntegrity, SwitchActivityInfo, SwitchCycleDuration
 
             if(counterValid == stopCounting) {
                 s_endTime.setNowNonInline();
+                // Disarm timer
+                timer.it_value.tv_sec = 0;
+                timer.it_value.tv_usec = 0;
+                if (setitimer(ITIMER_REAL, &timer, NULL)) {
+                    log_err("ERROR: setitimer() failed when disarming");
+                }
                 log_msg("Test end (finished observation count)");
                 g_b_exit = true;
             }

--- a/src/defs.h
+++ b/src/defs.h
@@ -137,6 +137,7 @@ const uint32_t TEST_FIRST_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC = 50;
 #define DEFAULT_PORT 11111
 #define DEFAULT_IP_MTU 1500
 #define DEFAULT_IP_PAYLOAD_SZ (DEFAULT_IP_MTU - 28)
+#define DEFAULT_CI_SIG_LEVEL 99
 #define DUMMY_PORT 57341
 #define MAX_ACTIVE_FD_NUM                                                                          \
     1024 /* maximum number of active connection to the single TCP addr:port                        \
@@ -225,7 +226,8 @@ enum {
     OPT_DUMMY_SEND,               // 41
     OPT_RATE_LIMIT,               // 42
     OPT_UC_REUSEADDR,             // 43
-    OPT_FULL_RTT                  // 44
+    OPT_FULL_RTT,                 // 44
+    OPT_CI_SIG_LVL                // 45
 };
 
 static const char *const round_trip_str[] = { "latency", "rtt" };
@@ -677,6 +679,7 @@ struct user_params_t {
     bool increase_output_precision;  // client side only
     bool b_stream;                   // client side only
     PlaybackVector *pPlaybackVector; // client side only
+    uint32_t ci_significance_level;  // client side only
     struct sockaddr_in addr;
     int sock_type;
     bool tcp_nodelay;

--- a/src/defs.h
+++ b/src/defs.h
@@ -227,7 +227,11 @@ enum {
     OPT_RATE_LIMIT,               // 42
     OPT_UC_REUSEADDR,             // 43
     OPT_FULL_RTT,                 // 44
-    OPT_CI_SIG_LVL                // 45
+    OPT_CI_SIG_LVL,               // 45
+    OPT_HISTOGRAM,                // 46
+    OPT_HISTOGRAM_UPPER_RANGE,    // 47
+    OPT_HISTOGRAM_LOWER_RANGE,    // 48
+    OPT_HISTOGRAM_BIN_SIZE        // 49
 };
 
 static const char *const round_trip_str[] = { "latency", "rtt" };
@@ -680,6 +684,10 @@ struct user_params_t {
     bool b_stream;                   // client side only
     PlaybackVector *pPlaybackVector; // client side only
     uint32_t ci_significance_level;  // client side only
+    bool b_histogram;                // client side only
+    uint32_t histogram_lower_range;  // client side only
+    uint32_t histogram_upper_range;  // client side only
+    uint32_t histogram_bin_size;     // client side only
     struct sockaddr_in addr;
     int sock_type;
     bool tcp_nodelay;

--- a/src/defs.h
+++ b/src/defs.h
@@ -123,6 +123,8 @@ const uint32_t REPLY_EVERY_DEFAULT = 100;
 
 const uint32_t TEST_START_WARMUP_MSEC = 400;
 const uint32_t TEST_END_COOLDOWN_MSEC = 50;
+const uint32_t TEST_START_WARMUP_OBS = 8000;
+const uint32_t TEST_END_COOLDOWN_OBS = 1000;
 
 const uint32_t TEST_FIRST_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC = 50;
 #define TEST_ANY_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC (0.1)
@@ -130,6 +132,7 @@ const uint32_t TEST_FIRST_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC = 50;
 #define DEFAULT_CLIENT_WORK_WITH_SRV_NUM 1
 
 #define DEFAULT_TEST_DURATION 1 /* [sec] */
+#define DEFAULT_OBSERVATION_COUNT 0
 #define DEFAULT_MC_ADDR "0.0.0.0"
 #define DEFAULT_PORT 11111
 #define DEFAULT_IP_MTU 1500
@@ -160,6 +163,7 @@ const uint32_t TEST_FIRST_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC = 50;
 
 #define MAX_ARGV_SIZE 256
 #define MAX_DURATION 36000000
+#define MAX_OBSERVATIONS 100000000
 extern const int MAX_FDS_NUM;
 #define SOCK_BUFF_DEFAULT_SIZE 0
 #define DEFAULT_SELECT_TIMEOUT_MSEC 10
@@ -607,6 +611,11 @@ typedef enum {
     MODE_BRIDGE
 } work_mode_t;
 
+typedef enum {
+    TIME_BASED = 1,
+    OBSERVATION_BASED
+} measurement_mode_t;
+
 typedef enum { // must be coordinated with s_fds_handle_desc in common.cpp
     RECVFROM = 0,
     RECVFROMMUX,
@@ -619,13 +628,15 @@ typedef enum { // must be coordinated with s_fds_handle_desc in common.cpp
     FD_HANDLE_MAX } fd_block_handler_t;
 
 struct user_params_t {
-    work_mode_t mode; // either  client or server
+    work_mode_t mode; // either client or server
+    measurement_mode_t measurement; // either time or observation
     struct in_addr rx_mc_if_addr;
     struct in_addr tx_mc_if_addr;
     struct in_addr mc_source_ip_addr;
     int msg_size;
     int msg_size_range;
     int sec_test_duration;
+    uint32_t observation_test_count;
     bool data_integrity;
     fd_block_handler_t fd_handler_type;
     unsigned int packetrate_stats_print_ratio;
@@ -642,6 +653,8 @@ struct user_params_t {
     unsigned int pre_warmup_wait;
     uint32_t cooldown_msec;
     uint32_t warmup_msec;
+    uint64_t cooldown_obs;
+    uint64_t warmup_obs;
     bool is_vmarxfiltercb;
     bool is_vmazcopyread;
     TicksDuration cycleDuration;

--- a/src/defs.h
+++ b/src/defs.h
@@ -138,6 +138,8 @@ const uint32_t TEST_FIRST_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC = 50;
 #define MAX_ACTIVE_FD_NUM                                                                          \
     1024 /* maximum number of active connection to the single TCP addr:port                        \
             */
+#define DEFAULT_BUF_ALIGNMENT 512
+#define DEFAULT_FILE_FLAGS_OPT 0
 #ifdef USING_VMA_EXTRA_API
 #define MAX_VMA_COMPS 1024 /* maximum size for the VMA completions array for VMA Poll */
 #endif
@@ -221,7 +223,10 @@ enum {
     OPT_DUMMY_SEND,               // 41
     OPT_RATE_LIMIT,               // 42
     OPT_UC_REUSEADDR,             // 43
-    OPT_FULL_RTT                  // 44
+    OPT_FULL_RTT,                 // 44
+    OPT_WRITE_MSG_FILE_PATH,      // 45
+    OPT_WRITE_MSG_FILE_FLAGS,     // 46
+    OPT_WRITE_MSG_BUF_ALIGN       // 47
 };
 
 static const char *const round_trip_str[] = { "latency", "rtt" };
@@ -679,6 +684,10 @@ struct user_params_t {
     uint32_t dummy_mps;                   // client side only
     TicksDuration dummySendCycleDuration; // client side only
     uint32_t rate_limit;
+    bool b_write_msg_to_file;
+    char write_msg_filepath[MAX_PATH_LENGTH];
+    uint32_t write_msg_file_flags_opt;
+    uint32_t write_msg_buf_alignment;
 };
 
 struct mutable_params_t {};

--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -137,9 +137,9 @@ static const struct app_modes {
         aopt_set_string("ul"), "Run " MODULE_NAME " client for latency under load test." },
       { proc_mode_ping_pong,   "ping-pong",
         aopt_set_string("pp"), "Run " MODULE_NAME " client for latency test in ping pong mode." },
-      { proc_mode_playback, "playback", aopt_set_string("pb"),
-        "Run " MODULE_NAME " client for latency test using playback of predefined traffic, based "
-        "on timeline and message size." },
+      { proc_mode_playback, "playback",
+        aopt_set_string("pb"), "Run " MODULE_NAME " client for latency test using playback of predefined"
+                                                  " traffic, based on timeline and message size." },
       { proc_mode_throughput,  "throughput",
         aopt_set_string("tp"), "Run " MODULE_NAME " client for one way throughput test." },
       { proc_mode_server, "server", aopt_set_string("sr"), "Run " MODULE_NAME " as a server." },
@@ -648,6 +648,9 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
         { 't',                                                 AOPT_ARG,
           aopt_set_literal('t'),                               aopt_set_string("time"),
           "Run for <sec> seconds (default 1, max = 36000000)." },
+        { 'n',                                                 AOPT_ARG,
+          aopt_set_literal('n'),                               aopt_set_string("number-of-observations"),
+          "Run for observations (default 0, max = 100000000)." },
         { OPT_CLIENTPORT,
           AOPT_ARG,
           aopt_set_literal(0),
@@ -704,6 +707,7 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
 
     /* Set default values */
     s_user_params.mode = MODE_CLIENT;
+    s_user_params.measurement = TIME_BASED;
     s_user_params.b_client_ping_pong = true;
     s_user_params.mps = UINT32_MAX;
     s_user_params.reply_every = 1;
@@ -720,6 +724,24 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
 
     /* Set command line specific values */
     if (!rc && self_obj) {
+        if (!rc && aopt_check(self_obj, 'n')) {
+            const char *optarg = aopt_value(self_obj, 'n');
+            if (optarg) {
+                errno = 0;
+                int value = strtol(optarg, NULL, 0);
+                if (errno != 0 || value <= 0 || value > MAX_OBSERVATIONS) {
+                    log_msg("'-%c' Invalid observations: %s", 'n', optarg);
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                } else {
+                    s_user_params.measurement = OBSERVATION_BASED;
+                    s_user_params.observation_test_count = value;
+                }
+            } else {
+                log_msg("'-%c' Invalid value", 'n');
+                rc = SOCKPERF_ERR_BAD_ARGUMENT;
+            }
+        }
+
         if (!rc && aopt_check(self_obj, 't')) {
             const char *optarg = aopt_value(self_obj, 't');
             if (optarg) {
@@ -729,7 +751,13 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
                     log_msg("'-%c' Invalid duration: %s", 't', optarg);
                     rc = SOCKPERF_ERR_BAD_ARGUMENT;
                 } else {
-                    s_user_params.sec_test_duration = value;
+                    if (s_user_params.measurement == OBSERVATION_BASED) {
+                        log_msg("Can't be both observation and time based");
+                        rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                    } else {
+                        s_user_params.measurement = TIME_BASED;
+                        s_user_params.sec_test_duration = value;
+                    }
                 }
             } else {
                 log_msg("'-%c' Invalid value", 't');
@@ -873,10 +901,10 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
         printf("%s: %s\n", display_opt(id, temp_buf, sizeof(temp_buf)), sockperf_modes[id].note);
         printf("\n");
         printf("Usage: " MODULE_NAME " %s [options] [args]...\n", sockperf_modes[id].name);
-        printf(" " MODULE_NAME " %s -i ip  [-p port] [-m message_size] [-t time]\n",
+        printf(" " MODULE_NAME " %s -i ip  [-p port] [-m message_size] [-t time | -n number-of-observations]\n",
                sockperf_modes[id].name);
         printf(" " MODULE_NAME
-               " %s -f file [-F s/p/e] [-m message_size] [-r msg_size_range] [-t time]\n",
+               " %s -f file [-F s/p/e] [-m message_size] [-r msg_size_range] [-t time | -n number-of-observations]\n",
                sockperf_modes[id].name);
         printf("\n");
         printf("Options:\n");
@@ -2159,10 +2187,12 @@ void set_defaults() {
     s_user_params.tx_mc_if_addr.s_addr = htonl(INADDR_ANY);
     s_user_params.mc_source_ip_addr.s_addr = htonl(INADDR_ANY);
     s_user_params.sec_test_duration = DEFAULT_TEST_DURATION;
+    s_user_params.observation_test_count = DEFAULT_OBSERVATION_COUNT;
     s_user_params.client_bind_info.sin_family = AF_INET;
     s_user_params.client_bind_info.sin_addr.s_addr = INADDR_ANY;
     s_user_params.client_bind_info.sin_port = 0;
     s_user_params.mode = MODE_SERVER;
+    s_user_params.measurement = TIME_BASED;
     s_user_params.packetrate_stats_print_ratio = 0;
     s_user_params.packetrate_stats_print_details = false;
     s_user_params.burst_size = 1;
@@ -3214,6 +3244,8 @@ int bringup(const int *p_daemonize) {
                 TEST_FIRST_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC * 1000,
                 (int)(TEST_ANY_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC * 1000));
         }
+        s_user_params.warmup_obs = TEST_START_WARMUP_OBS;
+        s_user_params.cooldown_obs = TEST_END_COOLDOWN_OBS;
 
         uint64_t _maxTestDuration = 1 + s_user_params.sec_test_duration +
                                     (s_user_params.warmup_msec + s_user_params.cooldown_msec) /
@@ -3221,6 +3253,11 @@ int bringup(const int *p_daemonize) {
         uint64_t _maxSequenceNo = _maxTestDuration * s_user_params.mps +
                                   10 * s_user_params.reply_every; // + 10 replies for safety
         _maxSequenceNo += s_user_params.burst_size; // needed for the case burst_size > mps
+
+        if(s_user_params.measurement == OBSERVATION_BASED) {
+            // override to reach max count during observation based
+            _maxSequenceNo = TEST_START_WARMUP_OBS + MAX_OBSERVATIONS + TEST_END_COOLDOWN_OBS;
+        }
 
         if (s_user_params.pPlaybackVector) {
             _maxSequenceNo = s_user_params.pPlaybackVector->size();
@@ -3324,10 +3361,12 @@ int main(int argc, char *argv[]) {
         log_dbg(
             "+INFO:\n\t\
 mode = %d \n\t\
+measurement = %d \n\t\
 with_sock_accl = %d \n\t\
 msg_size = %d \n\t\
 msg_size_range = %d \n\t\
 sec_test_duration = %d \n\t\
+observation_test_count = %d \n\t\
 data_integrity = %d \n\t\
 packetrate_stats_print_ratio = %d \n\t\
 burst_size = %d \n\t\
@@ -3363,14 +3402,14 @@ daemonize = %d \n\t\
 feedfile_name = %s \n\t\
 tos = %d \n\t\
 packet pace limit = %d",
-            s_user_params.mode, s_user_params.withsock_accl, s_user_params.msg_size,
-            s_user_params.msg_size_range, s_user_params.sec_test_duration,
-            s_user_params.data_integrity, s_user_params.packetrate_stats_print_ratio,
-            s_user_params.burst_size, s_user_params.packetrate_stats_print_details,
-            s_user_params.fd_handler_type, s_user_params.mthread_server,
-            s_user_params.sock_buff_size, s_user_params.threads_num, s_user_params.threads_affinity,
-            s_user_params.is_blocked, s_user_params.is_nonblocked_send, s_user_params.do_warmup,
-            s_user_params.pre_warmup_wait, s_user_params.is_vmarxfiltercb,
+            s_user_params.mode, s_user_params.measurement, s_user_params.withsock_accl,
+            s_user_params.msg_size, s_user_params.msg_size_range, s_user_params.sec_test_duration,
+            s_user_params.observation_test_count, s_user_params.data_integrity,
+            s_user_params.packetrate_stats_print_ratio, s_user_params.burst_size,
+            s_user_params.packetrate_stats_print_details, s_user_params.fd_handler_type,
+            s_user_params.mthread_server, s_user_params.sock_buff_size, s_user_params.threads_num,
+            s_user_params.threads_affinity, s_user_params.is_blocked, s_user_params.is_nonblocked_send,
+            s_user_params.do_warmup, s_user_params.pre_warmup_wait, s_user_params.is_vmarxfiltercb,
             s_user_params.is_vmazcopyread, s_user_params.mc_loop_disable, s_user_params.mc_ttl,
             s_user_params.uc_reuseaddr, s_user_params.tcp_nodelay,
             s_user_params.client_work_with_srv_num, s_user_params.b_server_reply_via_uc,

--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -138,8 +138,8 @@ static const struct app_modes {
       { proc_mode_ping_pong,   "ping-pong",
         aopt_set_string("pp"), "Run " MODULE_NAME " client for latency test in ping pong mode." },
       { proc_mode_playback, "playback",
-        aopt_set_string("pb"), "Run " MODULE_NAME " client for latency test using playback of predefined"
-                                                  " traffic, based on timeline and message size." },
+        aopt_set_string("pb"), "Run " MODULE_NAME " client for latency test using playback of predefined "
+                               "traffic, based on timeline and message size." },
       { proc_mode_throughput,  "throughput",
         aopt_set_string("tp"), "Run " MODULE_NAME " client for one way throughput test." },
       { proc_mode_server, "server", aopt_set_string("sr"), "Run " MODULE_NAME " as a server." },
@@ -395,6 +395,12 @@ static int proc_mode_under_load(int id, int argc, const char **argv) {
           aopt_set_literal('r'),
           aopt_set_string("range"),
           "comes with -m <size>, randomly change the messages size in range: <size> +- <N>." },
+        { OPT_CI_SIG_LVL,
+          AOPT_OPTARG,
+          aopt_set_literal(0),
+          aopt_set_string("ci_sig_level"),
+          "Normal confidence interval significance level for stat reported. Values are between 0 and 100 "
+          "exclusive (default 99). " },
         { 0, AOPT_NOARG, aopt_set_literal(0), aopt_set_string(NULL), NULL }
     };
 
@@ -590,6 +596,25 @@ static int proc_mode_under_load(int id, int argc, const char **argv) {
                 rc = SOCKPERF_ERR_BAD_ARGUMENT;
             }
         }
+
+        if (!rc && aopt_check(self_obj, OPT_CI_SIG_LVL)) {
+            const char *optarg = aopt_value(self_obj, OPT_CI_SIG_LVL);
+            if (optarg) {
+                errno = 0;
+                int value = strtol(optarg, NULL, 0);
+                if (errno != 0 || value <= 0 || value >= 100) {
+                    log_msg("'--%s' Invalid Significance level: %s",
+                        aopt_get_long_name(self_opt_desc, OPT_CI_SIG_LVL), optarg);
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                } else {
+                    s_user_params.ci_significance_level = value;
+                }
+            } else {
+                log_msg("'--%s' Invalid value",
+                    aopt_get_long_name(self_opt_desc, OPT_CI_SIG_LVL));
+                rc = SOCKPERF_ERR_BAD_ARGUMENT;
+            }
+        }
     }
 
     if (rc) {
@@ -679,6 +704,12 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
           "comes with -m <size>, randomly change the messages size in range: <size> +- <N>." },
         { OPT_DATA_INTEGRITY,                AOPT_NOARG,                    aopt_set_literal(0),
           aopt_set_string("data-integrity"), "Perform data integrity test." },
+        { OPT_CI_SIG_LVL,
+          AOPT_OPTARG,
+          aopt_set_literal(0),
+          aopt_set_string("ci_sig_level"),
+          "Normal confidence interval significance level for stat reported. Values are between 0 and 100 "
+          "exclusive (default 99). " },
         { 0, AOPT_NOARG, aopt_set_literal(0), aopt_set_string(NULL), NULL }
     };
 
@@ -889,6 +920,25 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
                 s_user_params.data_integrity = true;
             } else {
                 log_msg("--data-integrity conflicts with -b option");
+                rc = SOCKPERF_ERR_BAD_ARGUMENT;
+            }
+        }
+
+        if (!rc && aopt_check(self_obj, OPT_CI_SIG_LVL)) {
+            const char *optarg = aopt_value(self_obj, OPT_CI_SIG_LVL);
+            if (optarg) {
+                errno = 0;
+                int value = strtol(optarg, NULL, 0);
+                if (errno != 0 || value <= 0 || value >= 100) {
+                    log_msg("'--%s' Invalid Significance level: %s",
+                        aopt_get_long_name(self_opt_desc, OPT_CI_SIG_LVL), optarg);
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                } else {
+                    s_user_params.ci_significance_level = value;
+                }
+            } else {
+                log_msg("'--%s' Invalid value",
+                    aopt_get_long_name(self_opt_desc, OPT_CI_SIG_LVL));
                 rc = SOCKPERF_ERR_BAD_ARGUMENT;
             }
         }
@@ -1225,6 +1275,12 @@ static int proc_mode_playback(int id, int argc, const char **argv) {
         { OPT_PLAYBACK_DATA,                                         AOPT_ARG,
           aopt_set_literal(0),                                       aopt_set_string("data-file"),
           "Pre-prepared CSV file with timestamps and message sizes." },
+        { OPT_CI_SIG_LVL,
+          AOPT_OPTARG,
+          aopt_set_literal(0),
+          aopt_set_string("ci_sig_level"),
+          "Normal confidence interval significance level for stat reported. Values are between 0 and 100 "
+          "exclusive (default 99). " },
         { 0, AOPT_NOARG, aopt_set_literal(0), aopt_set_string(NULL), NULL }
     };
 
@@ -1293,6 +1349,25 @@ static int proc_mode_playback(int id, int argc, const char **argv) {
                 }
             } else {
                 log_msg("'-%d' Invalid value", OPT_REPLY_EVERY);
+                rc = SOCKPERF_ERR_BAD_ARGUMENT;
+            }
+        }
+
+        if (!rc && aopt_check(self_obj, OPT_CI_SIG_LVL)) {
+            const char *optarg = aopt_value(self_obj, OPT_CI_SIG_LVL);
+            if (optarg) {
+                errno = 0;
+                int value = strtol(optarg, NULL, 0);
+                if (errno != 0 || value <= 0 || value >= 100) {
+                    log_msg("'--%s' Invalid Significance level: %s",
+                        aopt_get_long_name(self_opt_desc, OPT_CI_SIG_LVL), optarg);
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                } else {
+                    s_user_params.ci_significance_level = value;
+                }
+            } else {
+                log_msg("'--%s' Invalid value",
+                    aopt_get_long_name(self_opt_desc, OPT_CI_SIG_LVL));
                 rc = SOCKPERF_ERR_BAD_ARGUMENT;
             }
         }
@@ -2191,6 +2266,7 @@ void set_defaults() {
     s_user_params.client_bind_info.sin_family = AF_INET;
     s_user_params.client_bind_info.sin_addr.s_addr = INADDR_ANY;
     s_user_params.client_bind_info.sin_port = 0;
+    s_user_params.ci_significance_level = DEFAULT_CI_SIG_LEVEL;
     s_user_params.mode = MODE_SERVER;
     s_user_params.measurement = TIME_BASED;
     s_user_params.packetrate_stats_print_ratio = 0;

--- a/src/ticks.h
+++ b/src/ticks.h
@@ -345,6 +345,18 @@ public:
     //------------------------------------------------------------------------------
     static TicksDuration stdDev(TicksDuration *pArr, size_t size);
 
+    //------------------------------------------------------------------------------
+    static TicksDuration mad(TicksDuration *pArr, size_t size);
+
+    //------------------------------------------------------------------------------
+    static TicksDuration medianad(TicksDuration *pArr, size_t size);
+
+    //------------------------------------------------------------------------------
+    static TicksDuration siqr(TicksDuration *pArr, size_t size);
+
+    //------------------------------------------------------------------------------
+    static TicksDuration median(TicksDuration *pArr, size_t size, bool sortList);
+
 private:
     inline explicit TicksDuration(ticks_t _ticks, bool) : TicksBase(_ticks) {}
     explicit TicksDuration(int64_t _nsec, int); // provide non inline function for reducing code


### PR DESCRIPTION
**Motive:**

Currently, sockperf runs until a timer completes which produces an undetermined number of data rows. Observational-based measurements produce an exact number which eases sockperf run comparisons (such as with stats) and avoids potential overflow during high data collection. Compute more stats directly from measurements to take advantage of sockperf's `ticks` (nanosecond precision). Produce microsecond resolution sparse fixed bin histogram from measurements to provide a visual display of data.

**Changes:**
Obervational-based
- Parser accepts `-n` for number of observations. This measurement type is only for ping-pong mode
- Observational warmup/cooldown when in observational mode instead of adding warmup/cooldown time to timer
- Tracking valid observations in `doSendThenReceiveLoop`, where `client_send_then_receive` is blocking
- Time cap based on warm up sample to limit waiting on observations

Stats
- Add mean absolute deviation, median absolute deviation, semi-interquartile range, coefficient of variance, standard error, and confidence interval 
- Confidence interval significance level configurable via arg flag `--ci_sig_level` (includes decimals)
- Inverse CDF (or ppf) function to compute confidence interval  for any significance level (0-100 exclusive)
- Getter for long name of options for logging purposes
- Sort latency list once where other stats can reuse

Histogram
- Build histogram and display histogram on terminal for a quick view (frequency rounded up)
- Store raw histogram data to log file if present
- Histogram flag, bin size, lower range, and upper range of interest are configurable via cmd args,respectively `-histogram` `--h_bin_size_us` `--h_lower_range_us` `--h_upper_range_us`
- Left and right outlier bins to capture all data outside given range

**Manual Self-Testing:**
Ran server and client locally and manually verified logX.txt had the expected observational data count.
`./sockperf sr -i 127.0.0.1`
`./sockperf pp -i 127.0.0.1 -n 1000 -m 64 --full-log log.txt` -> 1000
`./sockperf pp -i 127.0.0.1 -n 1         -m 64 --full-log logA.txt` -> 1\
`./sockperf pp -i 127.0.0.1 -n -1        -m 64 --full-log logC.txt` -> failed to help page as expected
`./sockperf pp -i 127.0.0.1 -n 100000001 -m 64 --full-log logD.txt` -> failed to help page as expected
`./sockperf pp -i 127.0.0.1 -n 100000000 -m 64 --full-log logE.txt` -> 100000000 (max obs imposed)


`./sockperf pp -i 127.0.0.1 -n 1000 -m 64 --ci_sig_level 80 --full-log log.txt --full-rtt`
All stat changes are reported in magenta line `sockperf: ====> avg-rtt...`.
![image](https://user-images.githubusercontent.com/20761371/108804256-c3639a80-756a-11eb-963c-53ea3cbccb45.png)


`./sockperf pp -i 127.0.0.1 -n 1000000 -m 64 --histogram --h_lower_range_us 25 --h_upper_range_us 60 --h_bin_size_us 1 --full-log log.txt --full-rtt`
All histogram changes are after `sockperf: [Histogram]...`
![histo1](https://user-images.githubusercontent.com/20761371/112075510-e5cee080-8b35-11eb-943e-ea9624217f84.png)

Raw histogram content at the end of log file:
```
------------------------------
histogram was built using the following parameters: --h_bin_size_us=1 --h_lower_range_us=25 --h_upper_range_us=60
------------------------------
bin (usec), frequency
19-25,          360
25,             462
26,             678
27,             667
28,             954
29,             2176
30,             7270
31,             22381
32,             52176
33,             95764
34,             155682
35,             208057
36,             129830
37,             99863
38,             31053
39,             16956
40,             13086
41,             10095
42,             7562
43,             6284
44,             5583
45,             5113
46,             5127
47,             5928
48,             7408
49,             10500
50,             13064
51,             13854
52,             11874
53,             8260
54,             5151
55,             3450
56,             2759
57,             2287
58,             2079
59,             1616
60-12679,               34591
------------------------------
```