### PR TITLE
issue: 2597798 Add observation based measurement, more stats, and histogram 2

### DIFF
--- a/src/aopt.cpp
+++ b/src/aopt.cpp
@@ -310,13 +310,13 @@ const char *aopt_value(const AOPT_OBJECT *aopt_obj, int key) {
  * @retval NULL - on failure
  ***************************************************************************/
 const AOPT_DESC *aopt_get_desc(const AOPT_DESC *aopt_desc, int key) {
+    const AOPT_DESC *desc = NULL;
+    int i = 0;
+
     if (key == 0) {
         log_err("Not a valid key for aopt");
         return NULL;
     }
-
-    const AOPT_DESC *desc = NULL;
-    int i = 0;
 
     while(aopt_desc[i].key != 0) {
         if(aopt_desc[i].key == key) {

--- a/src/aopt.cpp
+++ b/src/aopt.cpp
@@ -298,6 +298,59 @@ const char *aopt_value(const AOPT_OBJECT *aopt_obj, int key) {
 }
 
 /**
+ * aopt_get_desc
+ *
+ * @brief
+ *    Return AOPT Description struct of option selected via key.
+ *
+ * @param[in]    desc           Option description.
+ * @param[in]    key            Option key.
+ *
+ * @retval pointer to description struct - on success
+ * @retval NULL - on failure
+ ***************************************************************************/
+const AOPT_DESC *aopt_get_desc(const AOPT_DESC *aopt_desc, int key) {
+    if (key == 0) {
+        log_err("Not a valid key for aopt");
+        return NULL;
+    }
+
+    const AOPT_DESC *desc = NULL;
+    int i = 0;
+
+    while(aopt_desc[i].key != 0) {
+        if(aopt_desc[i].key == key) {
+            desc = &aopt_desc[i];
+            break;
+        }
+        i++;
+    }
+
+    return desc;
+}
+
+/**
+ * aopt_get_long_name
+ *
+ * @brief
+ *    Return long name of option description selected via key.
+ *
+ * @param[in]    desc           Option description.
+ * @param[in]    key            Option key.
+ *
+ * @retval pointer to string - on success
+ * @retval NULL - on failure
+ ***************************************************************************/
+const char *aopt_get_long_name(const AOPT_DESC *aopt_desc, int key) {
+    if (key == 0) {
+        log_err("Not a valid key for aopt");
+        return NULL;
+    }
+
+    return *aopt_get_desc(aopt_desc, key)->longs;
+}
+
+/**
  * aopt_help
  *
  * @brief

--- a/src/aopt.cpp
+++ b/src/aopt.cpp
@@ -340,12 +340,14 @@ const AOPT_DESC *aopt_get_desc(const AOPT_DESC *aopt_desc, int key) {
  * @retval NULL - on failure
  ***************************************************************************/
 const char *aopt_get_long_name(const AOPT_DESC *aopt_desc, int key) {
-    if (key == 0 || aopt_get_desc(aopt_desc, key) == NULL) {
+    const AOPT_DESC *desc = aopt_get_desc(aopt_desc, key);
+
+    if (key == 0 || desc == NULL) {
         log_err("Not a valid key for aopt. Tried getting long name");
         return NULL;
     }
 
-    return *aopt_desc->longs;
+    return *desc->longs;
 }
 
 /**

--- a/src/aopt.cpp
+++ b/src/aopt.cpp
@@ -311,19 +311,17 @@ const char *aopt_value(const AOPT_OBJECT *aopt_obj, int key) {
  ***************************************************************************/
 const AOPT_DESC *aopt_get_desc(const AOPT_DESC *aopt_desc, int key) {
     const AOPT_DESC *desc = NULL;
-    int i = 0;
 
     if (key == 0) {
-        log_err("Not a valid key for aopt");
+        log_err("Not a valid key for aopt. Tried getting descriptor");
         return NULL;
     }
 
-    while(aopt_desc[i].key != 0) {
-        if(aopt_desc[i].key == key) {
+    for (int i = 0; aopt_desc[i].key != 0; ++i) {
+        if (aopt_desc[i].key == key) {
             desc = &aopt_desc[i];
             break;
         }
-        i++;
     }
 
     return desc;
@@ -342,12 +340,12 @@ const AOPT_DESC *aopt_get_desc(const AOPT_DESC *aopt_desc, int key) {
  * @retval NULL - on failure
  ***************************************************************************/
 const char *aopt_get_long_name(const AOPT_DESC *aopt_desc, int key) {
-    if (key == 0) {
-        log_err("Not a valid key for aopt");
+    if (key == 0 || aopt_get_desc(aopt_desc, key) == NULL) {
+        log_err("Not a valid key for aopt. Tried getting long name");
         return NULL;
     }
 
-    return *aopt_get_desc(aopt_desc, key)->longs;
+    return *aopt_desc->longs;
 }
 
 /**

--- a/src/aopt.h
+++ b/src/aopt.h
@@ -161,6 +161,34 @@ int aopt_check(const AOPT_OBJECT *aopt_obj, int key);
 const char *aopt_value(const AOPT_OBJECT *aopt_obj, int key);
 
 /**
+ * aopt_get_desc
+ *
+ * @brief
+ *    Return AOPT Description struct of option selected via key.
+ *
+ * @param[in]    desc           Option description.
+ * @param[in]    key            Option key.
+ *
+ * @retval pointer to description struct - on success
+ * @retval NULL - on failure
+ ***************************************************************************/
+const AOPT_DESC *aopt_get_desc(const AOPT_DESC *aopt_desc, int key);
+
+/**
+ * aopt_get_long_name
+ *
+ * @brief
+ *    Return long name of option description selected via key.
+ *
+ * @param[in]    desc           Option description.
+ * @param[in]    key            Option key.
+ *
+ * @retval pointer to string - on success
+ * @retval NULL - on failure
+ ***************************************************************************/
+const char *aopt_get_long_name(const AOPT_DESC *aopt_desc, int key);
+
+/**
  * aopt_help
  *
  * @brief

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -197,8 +197,14 @@ void printHistogram(int binSize, std::map<int, int> &activeBins, int minValue, i
             maxFrequency = currFrequency;
         }
     }
-    maxDisplayWidth = terminalWidth - prefixToHistogramDisplay.length();
-    scalingUnit = (maxFrequency + maxDisplayWidth - 1)/maxDisplayWidth; // round up
+    if(terminalWidth == 0) {
+        // This may happen when run without terminal, but we still want the file output to contain the display
+        int standardTerminalLength = 80;
+        scalingUnit = (maxFrequency + standardTerminalLength - 1)/standardTerminalLength;
+    } else {
+        maxDisplayWidth = terminalWidth - prefixToHistogramDisplay.length();
+        scalingUnit = (maxFrequency + maxDisplayWidth - 1)/maxDisplayWidth; // round up
+    }
 
     int startBinEdge = 0;
     int endBinEdge = 0;
@@ -724,11 +730,19 @@ void Client<IoType, SwitchDataIntegrity, SwitchActivityInfo, SwitchCycleDuration
         FILE *f = g_pApp->m_const_params.fileFullLog;
         if (f) {
             fprintf(f, "------------------------------\n");
+            if (g_pApp->m_const_params.measurement == TIME_BASED) {
+                fprintf(f, "test was performed using the following parameters: "
+                        "--mps=%d --burst=%d --reply-every=%d --msg-size=%d --time=%d",
+                        (int)g_pApp->m_const_params.mps, (int)g_pApp->m_const_params.burst_size,
+                        (int)g_pApp->m_const_params.reply_every, (int)g_pApp->m_const_params.msg_size,
+                        (int)g_pApp->m_const_params.sec_test_duration);
+            } else {
             fprintf(f, "test was performed using the following parameters: "
-                       "--mps=%d --burst=%d --reply-every=%d --msg-size=%d --time=%d",
+                       "--mps=%d --burst=%d --reply-every=%d --msg-size=%d --number-of-observations=%" PRIu32 "",
                     (int)g_pApp->m_const_params.mps, (int)g_pApp->m_const_params.burst_size,
                     (int)g_pApp->m_const_params.reply_every, (int)g_pApp->m_const_params.msg_size,
-                    (int)g_pApp->m_const_params.sec_test_duration);
+                    g_pApp->m_const_params.observation_test_count);
+            }
             if (g_pApp->m_const_params.dummy_mps) {
                 fprintf(f, " --dummy-send=%d", g_pApp->m_const_params.dummy_mps);
             }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -78,7 +78,7 @@ void set_client_observation_timer(struct itimerval *timer, TicksTime testStart) 
     TicksDuration sampleTime = endSampling - testStart;
     uint64_t warmupObservations = s_user_params.warmup_obs;
     uint64_t cooldownObservations = s_user_params.cooldown_obs;
-    uint64_t observationTarget = g_pApp->m_const_params.observation_test_count;
+    uint64_t observationTarget = g_pApp->m_const_params.observation_count_target;
     uint64_t totalObservations = warmupObservations + observationTarget + cooldownObservations;
     uint64_t sampleObservations = warmupObservations;
 
@@ -465,7 +465,7 @@ void client_statistics(int serverNo, Message *pMsgRequest) {
 
     if (g_pApp->m_const_params.measurement == OBSERVATION_BASED) {
         start_searching_here += g_pApp->m_const_params.warmup_obs;
-        end_observation_here = start_searching_here + g_pApp->m_const_params.observation_test_count;
+        end_observation_here = start_searching_here + g_pApp->m_const_params.observation_count_target;
     }
 
     for (uint64_t i = start_searching_here; (counter < SIZE); i++) {
@@ -761,10 +761,10 @@ void Client<IoType, SwitchDataIntegrity, SwitchActivityInfo, SwitchCycleDuration
                         (int)g_pApp->m_const_params.sec_test_duration);
             } else {
             fprintf(f, "test was performed using the following parameters: "
-                       "--mps=%d --burst=%d --reply-every=%d --msg-size=%d --number-of-observations=%" PRIu32 "",
+                       "--mps=%d --burst=%d --reply-every=%d --msg-size=%d --number-of-observations=%" PRIu64 "",
                     (int)g_pApp->m_const_params.mps, (int)g_pApp->m_const_params.burst_size,
                     (int)g_pApp->m_const_params.reply_every, (int)g_pApp->m_const_params.msg_size,
-                    g_pApp->m_const_params.observation_test_count);
+                    g_pApp->m_const_params.observation_count_target);
             }
             if (g_pApp->m_const_params.dummy_mps) {
                 fprintf(f, " --dummy-send=%d", g_pApp->m_const_params.dummy_mps);
@@ -1004,7 +1004,7 @@ void Client<IoType, SwitchDataIntegrity, SwitchActivityInfo, SwitchCycleDuration
         uint64_t counterValid = 0;
         uint64_t warmupObservations = s_user_params.warmup_obs;
         uint64_t cooldownObservations = s_user_params.cooldown_obs;
-        uint64_t observationTarget = g_pApp->m_const_params.observation_test_count;
+        uint64_t observationTarget = g_pApp->m_const_params.observation_count_target;
         uint64_t stopCounting = warmupObservations + observationTarget + cooldownObservations;
         const uint64_t replyEvery = g_pApp->m_const_params.reply_every;
         const int SERVER_NO = 0; // TODO: should be one per server (as of 1/27/21 sockperf handles only one server)

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -757,11 +757,18 @@ void Client<IoType, SwitchDataIntegrity, SwitchActivityInfo, SwitchCycleDuration
         FILE *f = g_pApp->m_const_params.fileFullLog;
         if (f) {
             fprintf(f, "------------------------------\n");
+            if (g_pApp->m_const_params.measurement == TIME_BASED) {
+                fprintf(f, "test was performed using the following parameters: "
+                        "--mps=%d --burst=%d --reply-every=%d --msg-size=%d --time=%d",
+                        (int)g_pApp->m_const_params.mps, (int)g_pApp->m_const_params.burst_size,
+                        (int)g_pApp->m_const_params.reply_every, (int)g_pApp->m_const_params.msg_size,
+                        (int)g_pApp->m_const_params.sec_test_duration);
+            } else {
             fprintf(f, "test was performed using the following parameters: "
-                    "--mps=%d --burst=%d --reply-every=%d --msg-size=%d --time=%d",
-                    (int)g_pApp->m_const_params.mps, (int)g_pApp->m_const_params.burst_size,
-                    (int)g_pApp->m_const_params.reply_every, (int)g_pApp->m_const_params.msg_size,
-                    (int)g_pApp->m_const_params.sec_test_duration);
+                       "--burst=%d --msg-size=%d --number-of-packets=%" PRIu64 "",
+                        (int)g_pApp->m_const_params.burst_size,
+                        (int)g_pApp->m_const_params.msg_size, g_pApp->m_const_params.number_test_target);
+            }
             if (g_pApp->m_const_params.dummy_mps) {
                 fprintf(f, " --dummy-send=%d", g_pApp->m_const_params.dummy_mps);
             }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -33,6 +33,8 @@
 #include "packet.h"
 #include "switches.h"
 
+#include <math.h>
+
 TicksTime s_startTime, s_endTime;
 
 //==============================================================================
@@ -66,7 +68,7 @@ void set_client_timer(struct itimerval *timer) {
 //------------------------------------------------------------------------------
 /*  set the timer on client to limit waiting based on [-n number-of-observations] parameter given by
     user and sampling data */
-void set_client_time_out_timer(struct itimerval *timer, TicksTime testStart) {
+void set_client_observation_timer(struct itimerval *timer, TicksTime testStart) {
     /*  Based off observation rate during sampling, estimate total run time.
         Using warmup as our sample includes a bias for higher latency, because the head of
         the test has less load and receiver has no recent cache. This works to our benefit
@@ -94,10 +96,8 @@ void set_client_time_out_timer(struct itimerval *timer, TicksTime testStart) {
 }
 
 //------------------------------------------------------------------------------
-void printPercentiles(FILE *f, TicksDuration *pLat, size_t size) {
-    qsort(pLat, size, sizeof(TicksDuration), TicksDuration::compare);
-
-    double percentile[] = { 0.99999, 0.9999, 0.999, 0.99, 0.90, 0.75, 0.50, 0.25 };
+void printPercentiles(FILE *f, TicksDuration *sortedpLat, size_t size) {
+    const double percentile[] = { 0.99999, 0.9999, 0.999, 0.99, 0.90, 0.75, 0.50, 0.25 };
     int num = sizeof(percentile) / sizeof(percentile[0]);
     double observationsInPercentile = (double)size / 100;
 
@@ -105,22 +105,22 @@ void printPercentiles(FILE *f, TicksDuration *pLat, size_t size) {
                              "; each percentile contains %.2lf observations",
                   (long unsigned)size, observationsInPercentile);
 
-    log_msg_file2(f, "---> <MAX> observation = %8.3lf", pLat[size - 1].toDecimalUsec());
+    log_msg_file2(f, "---> <MAX> observation = %8.3lf", sortedpLat[size - 1].toDecimalUsec());
     for (int i = 0; i < num; i++) {
         int index = (int)(0.5 + percentile[i] * size) - 1;
         if (index >= 0) {
             log_msg_file2(f, "---> percentile %6.3lf = %8.3lf", 100 * percentile[i],
-                          pLat[index].toDecimalUsec());
+                          sortedpLat[index].toDecimalUsec());
         }
     }
-    log_msg_file2(f, "---> <MIN> observation = %8.3lf", pLat[0].toDecimalUsec());
+    log_msg_file2(f, "---> <MIN> observation = %8.3lf", sortedpLat[0].toDecimalUsec());
 }
 
 //------------------------------------------------------------------------------
 typedef TicksTime RecordLog[2];
 
 //------------------------------------------------------------------------------
-void dumpFullLog(int serverNo, RecordLog *pFullLog, size_t size, TicksDuration *pLat) {
+void dumpFullLog(int serverNo, RecordLog *pFullLog, size_t size) {
     FILE *f = g_pApp->m_const_params.fileFullLog;
     uint32_t denominator = g_pApp->m_const_params.full_rtt ? 1 : 2;
     if (!f || !size) return;
@@ -135,6 +135,36 @@ void dumpFullLog(int serverNo, RecordLog *pFullLog, size_t size, TicksDuration *
         fprintf(f, "%zu, %.9lf, %.9lf, %.3lf\n", i, tx, rx, result);
     }
     fprintf(f, "------------------------------\n");
+}
+
+//------------------------------------------------------------------------------
+double RationalApproximation(double t) {
+    // Abramowitz and Stegun formula 26.2.23
+    // with constants from here: https://arxiv.org/pdf/1002.0567.pdf, Section 3
+    // Absolute value of error should be less than 8 e-5
+    const double c[] = {2.653962002601684482, 1.561533700212080345, 0.061146735765196993};
+    const double d[] = {1.904875182836498708, 0.454055536444233510, 0.009547745327068945};
+    return t - ((c[2]*t + c[1])*t + c[0]) /
+        (((d[2]*t + d[1])*t + d[0])*t + 1.0);
+}
+
+//------------------------------------------------------------------------------
+double NormalCDFInverse(double p) {
+    if (p < 0.0 || p > 1.0) {
+        log_err("NormalCDFInverse only accepts 0 < p < 1");
+        return 0;
+    }
+
+    // Approximation function is only valid for (0 < p < .5)
+    // Extend to (0 < p < 1) by taking advantage of normal CDF inverse odd symmetry shape
+    // Detailed explanation here: https://www.johndcook.com/blog/normal_cdf_inverse/#basic
+    if (p < 0.5) {
+        // F^-1(p) = - G^-1(p)
+        return -RationalApproximation( sqrt(-2.0*log(p)) );
+    } else {
+        // F^-1(p) = G^-1(1-p)
+        return RationalApproximation( sqrt(-2.0*log(1-p)) );
+    }
 }
 
 //------------------------------------------------------------------------------
@@ -303,17 +333,30 @@ void client_statistics(int serverNo, Message *pMsgRequest) {
                       validRunTime.toDecimalUsec() / 1000000, (endValidSeqNo - startValidSeqNo + 1),
                       (uint64_t)counter);
 
+        TicksDuration::sort(pLat, counter);
+        TicksDuration *sortedpLat = &pLat[0]; // alias for pLat after being sorted
         TicksDuration avgRtt = counter ? sumRtt / (int)counter : TicksDuration::TICKS0;
         TicksDuration avgLatency = avgRtt / 2;
-        double usecAvarage =
-            g_pApp->m_const_params.full_rtt ? avgRtt.toDecimalUsec() : avgLatency.toDecimalUsec();
-
         TicksDuration stdDev = TicksDuration::stdDev(pLat, counter);
-        log_msg_file2(f, MAGNETA "====> avg-%s=%.3lf (std-dev=%.3lf)" ENDCOLOR,
-                      round_trip_str[g_pApp->m_const_params.full_rtt], usecAvarage,
-                      stdDev.toDecimalUsec());
+        TicksDuration mad = TicksDuration::mad(pLat, counter);
+        TicksDuration medianad = TicksDuration::medianad(pLat, counter);
+        TicksDuration siqr = TicksDuration::siqr(pLat, counter);
+        double usecAvarage = g_pApp->m_const_params.full_rtt ? avgRtt.toDecimalUsec() : avgLatency.toDecimalUsec();
+        double coefficientOfVariance = stdDev.toDecimalUsec() / usecAvarage;
+        double standardError = stdDev.toDecimalUsec() / sqrt(counter);
+        double significanceLevel = s_user_params.ci_significance_level;
+        double zScore = 1 - (1 - significanceLevel/100) / 2;
+        double confidenceLevelValue = NormalCDFInverse(zScore);
+        double lowerInterval = usecAvarage - confidenceLevelValue * standardError;
+        double upperInterval = usecAvarage + confidenceLevelValue * standardError;
+        log_msg_file2(f, MAGNETA "====> avg-%s=%.3lf (std-dev=%.3lf, mean-ad=%.3lf, median-ad=%.3lf, siqr=%.3lf, "
+            "cv=%.3lf, std-error=%.3lf, %.1lf%% ci=[%.3lf, %.3lf])" ENDCOLOR,
+            round_trip_str[g_pApp->m_const_params.full_rtt], usecAvarage,
+            stdDev.toDecimalUsec(), mad.toDecimalUsec(), medianad.toDecimalUsec(), siqr.toDecimalUsec(),
+            coefficientOfVariance, standardError, significanceLevel, lowerInterval, upperInterval);
 
-        /* Display ERROR statistic */
+        /* Display ERROR statistic*/
+
         bool isColor =
             (g_pPacketTimes->getDroppedCount(SERVER_NO) || g_pPacketTimes->getDupCount(SERVER_NO) ||
              g_pPacketTimes->getOooCount(SERVER_NO));
@@ -327,9 +370,9 @@ void client_statistics(int serverNo, Message *pMsgRequest) {
 
         if (usecAvarage) print_average_results(usecAvarage);
 
-        printPercentiles(f, pLat, counter);
+        printPercentiles(f, sortedpLat, counter);
 
-        dumpFullLog(SERVER_NO, pFullLog, counter, pLat);
+        dumpFullLog(SERVER_NO, pFullLog, counter);
     }
 
     delete[] pLat;
@@ -785,9 +828,9 @@ void Client<IoType, SwitchDataIntegrity, SwitchActivityInfo, SwitchCycleDuration
             prevRxTime = rxTime;
             counterValid++;
 
-            // Set timer to limit waiting on total observations
+            // Set timer to limit waiting on observations based off warmup sample
             if(counterValid == warmupObservations && timer.it_value.tv_sec == 0) {
-                set_client_time_out_timer(&timer, testStart);
+                set_client_observation_timer(&timer, testStart);
                 if (os_set_duration_timer(timer, client_sig_handler)) {
                     exit_with_log("Failed setting test observation timer", SOCKPERF_ERR_FATAL);
                 }
@@ -795,6 +838,12 @@ void Client<IoType, SwitchDataIntegrity, SwitchActivityInfo, SwitchCycleDuration
 
             if(counterValid == stopCounting) {
                 s_endTime.setNowNonInline();
+                // Disarm timer
+                timer.it_value.tv_sec = 0;
+                timer.it_value.tv_usec = 0;
+                if (setitimer(ITIMER_REAL, &timer, NULL)) {
+                    log_err("ERROR: setitimer() failed when disarming");
+                }
                 log_msg("Test end (finished observation count)");
                 g_b_exit = true;
             }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -64,6 +64,36 @@ void set_client_timer(struct itimerval *timer) {
 }
 
 //------------------------------------------------------------------------------
+/*  set the timer on client to limit waiting based on [-n number-of-observations] parameter given by
+    user and sampling data */
+void set_client_time_out_timer(struct itimerval *timer, TicksTime testStart) {
+    /*  Based off observation rate during sampling, estimate total run time.
+        Using warmup as our sample includes a bias for higher latency, because the head of
+        the test has less load and receiver has no recent cache. This works to our benefit
+        as we want an overestimate on waiting limit. */
+    TicksTime endSampling = endSampling.setNowNonInline();
+    TicksDuration sampleTime = endSampling - testStart;
+    uint64_t warmupObservations = s_user_params.warmup_obs;
+    uint64_t cooldownObservations = s_user_params.cooldown_obs;
+    uint64_t observationTarget = g_pApp->m_const_params.observation_test_count;
+    uint64_t totalObservations = warmupObservations + observationTarget + cooldownObservations;
+    uint64_t sampleObservations = warmupObservations;
+
+    // Calculate waiting limit                                          // (Units)
+    double sampleTimeSeconds = sampleTime.toDecimalUsec() / 1000000;    // secs
+    double sampleSecObsRate = sampleTimeSeconds / sampleObservations;   // secs/obs
+    double runTimeEstimate = sampleSecObsRate * totalObservations;      // (secs/obs)*obs = secs
+    double waitingCap = 1.5 * runTimeEstimate; // Add leeway to process stats and write to file
+    log_msg("RunTime Estimate=%.3lf sec, Time out in %.3lf sec", runTimeEstimate, waitingCap);
+
+    // Build timer
+    timer->it_value.tv_sec = waitingCap;
+    timer->it_value.tv_usec = 0;
+    timer->it_interval.tv_sec = 0;
+    timer->it_interval.tv_usec = 0;
+}
+
+//------------------------------------------------------------------------------
 void printPercentiles(FILE *f, TicksDuration *pLat, size_t size) {
     qsort(pLat, size, sizeof(TicksDuration), TicksDuration::compare);
 
@@ -126,16 +156,32 @@ void client_statistics(int serverNo, Message *pMsgRequest) {
     if (SERVER_NO == 0) {
         TicksDuration totalRunTime = s_endTime - s_startTime;
         if (g_skipCount) {
-            log_msg_file2(f, "[Total Run] RunTime=%.3lf sec; Warm up time=%" PRIu32
-                             " msec; SentMessages=%" PRIu64 "; ReceivedMessages=%" PRIu64
+            if(g_pApp->m_const_params.measurement == TIME_BASED) {
+                log_msg_file2(f, "[Total Run] RunTime=%.3lf sec; Warm up time=%" PRIu32
+                                " msec; SentMessages=%" PRIu64 "; ReceivedMessages=%" PRIu64
+                                "; SkippedMessages=%" PRIu64 "",
+                            totalRunTime.toDecimalUsec() / 1000000,
+                            g_pApp->m_const_params.warmup_msec, sendCount, receiveCount, g_skipCount);
+            } else {
+            log_msg_file2(f, "[Total Run] RunTime=%.3lf sec; Warm up observations=%" PRIu64
+                             "; SentMessages=%" PRIu64 "; ReceivedMessages=%" PRIu64
                              "; SkippedMessages=%" PRIu64 "",
                           totalRunTime.toDecimalUsec() / 1000000,
-                          g_pApp->m_const_params.warmup_msec, sendCount, receiveCount, g_skipCount);
+                          g_pApp->m_const_params.warmup_obs, sendCount, receiveCount, g_skipCount);
+            }
         } else {
-            log_msg_file2(f, "[Total Run] RunTime=%.3lf sec; Warm up time=%" PRIu32
-                             " msec; SentMessages=%" PRIu64 "; ReceivedMessages=%" PRIu64 "",
-                          totalRunTime.toDecimalUsec() / 1000000,
-                          g_pApp->m_const_params.warmup_msec, sendCount, receiveCount);
+            if(g_pApp->m_const_params.measurement == TIME_BASED) {
+                log_msg_file2(f, "[Total Run] RunTime=%.3lf sec; Warm up time=%" PRIu32
+                                " msec; SentMessages=%" PRIu64 "; ReceivedMessages=%" PRIu64 "",
+                            totalRunTime.toDecimalUsec() / 1000000,
+                            g_pApp->m_const_params.warmup_msec, sendCount, receiveCount);
+            }
+            else {
+                log_msg_file2(f, "[Total Run] RunTime=%.3lf sec; Warm up observations=%" PRIu64
+                                "; SentMessages=%" PRIu64 "; ReceivedMessages=%" PRIu64 "",
+                            totalRunTime.toDecimalUsec() / 1000000,
+                            g_pApp->m_const_params.warmup_obs, sendCount, receiveCount);
+            }
         }
     }
 
@@ -160,12 +206,18 @@ void client_statistics(int serverNo, Message *pMsgRequest) {
         g_pPacketTimes->getTxTime(sendCount); // will be "truncated" to last pong request packet
 
     if (!g_pApp->m_const_params.pPlaybackVector) { // no warmup in playback mode
-        testStart += TicksDuration::TICKS1MSEC * TEST_START_WARMUP_MSEC;
-        testEnd -= TicksDuration::TICKS1MSEC * TEST_END_COOLDOWN_MSEC;
+        if(g_pApp->m_const_params.measurement == TIME_BASED) {
+            testStart += TicksDuration::TICKS1MSEC * TEST_START_WARMUP_MSEC;
+            testEnd -= TicksDuration::TICKS1MSEC * TEST_END_COOLDOWN_MSEC;
+        }
     }
     log_dbg("testStart: %.9lf sec testEnd: %.9lf sec",
             (double)testStart.debugToNsec() / 1000 / 1000 / 1000,
             (double)testEnd.debugToNsec() / 1000 / 1000 / 1000);
+    if(testEnd < testStart) {
+        log_msg_file2(f, "Test end before test start. Ending statistics early");
+        return;
+    }
 
     TicksDuration *pLat = new TicksDuration[SIZE];
     RecordLog *pFullLog = g_pApp->m_const_params.fileFullLog ? new RecordLog[SIZE] : NULL;
@@ -173,19 +225,30 @@ void client_statistics(int serverNo, Message *pMsgRequest) {
     TicksDuration rtt;
     TicksDuration sumRtt(0);
     size_t counter = 0;
-    size_t lcounter = 0;
     TicksTime prevRxTime;
     TicksTime startValidTime;
     TicksTime endValidTime;
     uint32_t denominator = g_pApp->m_const_params.full_rtt ? 1 : 2;
     uint64_t startValidSeqNo = 0;
     uint64_t endValidSeqNo = 0;
-    for (size_t i = 1; (counter < SIZE) && (testStart < testEnd); i++) {
+    uint64_t start_searching_here = 1;
+    uint64_t end_observation_here = -1;
+
+    if (g_pApp->m_const_params.measurement == OBSERVATION_BASED) {
+        start_searching_here += g_pApp->m_const_params.warmup_obs;
+        end_observation_here = start_searching_here + g_pApp->m_const_params.observation_test_count;
+    }
+
+    for (uint64_t i = start_searching_here; (counter < SIZE); i++) {
         uint64_t seqNo = i * replyEvery;
         const TicksTime &txTime = g_pPacketTimes->getTxTime(seqNo);
         const TicksTime &rxTime = g_pPacketTimes->getRxTimeArray(seqNo)[SERVER_NO];
 
         if ((txTime > testEnd) || (txTime == TicksTime::TICKS0)) {
+            break;
+        }
+
+        if(g_pApp->m_const_params.measurement == OBSERVATION_BASED && seqNo >= end_observation_here) {
             break;
         }
 
@@ -213,10 +276,9 @@ void client_statistics(int serverNo, Message *pMsgRequest) {
         }
 
         if (g_pApp->m_const_params.fileFullLog) {
-            pFullLog[lcounter][0] = txTime;
-            pFullLog[lcounter][1] = rxTime;
+            pFullLog[counter][0] = txTime;
+            pFullLog[counter][1] = rxTime;
         }
-        lcounter++;
 
         endValidSeqNo = seqNo;
         endValidTime = rxTime;
@@ -232,7 +294,8 @@ void client_statistics(int serverNo, Message *pMsgRequest) {
 
     if (!counter) {
         log_msg_file2(
-            f, "No valid observations found. Try tune parameters: --time/--mps/--reply-every");
+            f, "No valid observations found. Try tune parameters: "
+               "--time/--number-of-observations/--mps/--reply-every");
     } else {
         TicksDuration validRunTime = endValidTime - startValidTime;
         log_msg_file2(f, "[Valid Duration] RunTime=%.3lf sec; SentMessages=%" PRIu64
@@ -266,7 +329,7 @@ void client_statistics(int serverNo, Message *pMsgRequest) {
 
         printPercentiles(f, pLat, counter);
 
-        dumpFullLog(SERVER_NO, pFullLog, lcounter, pLat);
+        dumpFullLog(SERVER_NO, pFullLog, counter, pLat);
     }
 
     delete[] pLat;
@@ -352,7 +415,12 @@ void client_sig_handler(int signum) {
 
     switch (signum) {
     case SIGALRM:
-        log_msg("Test end (interrupted by timer)");
+        if(g_pApp->m_const_params.measurement == TIME_BASED) {
+            log_msg("Test end (interrupted by timer)");
+        } else {
+            exit_with_log("Test ends uncompleted, observations taking too long (interrupted by timer)",
+                                                                                 SOCKPERF_ERR_TIMEOUT);
+        }
         break;
     case SIGINT:
         log_msg("Test end (interrupted by user)");
@@ -648,10 +716,12 @@ int Client<IoType, SwitchDataIntegrity, SwitchActivityInfo, SwitchCycleDuration,
 
                     if (!g_pApp->m_const_params.pPlaybackVector) {
                         struct itimerval timer;
-                        set_client_timer(&timer);
-                        if (os_set_duration_timer(timer, client_sig_handler)) {
-                            log_err("Failed setting test duration timer");
-                            rc = SOCKPERF_ERR_FATAL;
+                        if(g_pApp->m_const_params.measurement == TIME_BASED) {
+                            set_client_timer(&timer);
+                            if (os_set_duration_timer(timer, client_sig_handler)) {
+                                log_err("Failed setting test duration timer");
+                                rc = SOCKPERF_ERR_FATAL;
+                            }
                         }
                     }
 
@@ -673,9 +743,63 @@ template <class IoType, class SwitchDataIntegrity, class SwitchActivityInfo,
           class SwitchCycleDuration, class SwitchMsgSize, class PongModeCare>
 void Client<IoType, SwitchDataIntegrity, SwitchActivityInfo, SwitchCycleDuration, SwitchMsgSize,
             PongModeCare>::doSendThenReceiveLoop() {
-    // cycle through all set fds in the array (with wrap around to beginning)
-    for (int curr_fds = m_ioHandler.m_fd_min; !g_b_exit; curr_fds = g_fds_array[curr_fds]->next_fd)
-        client_send_then_receive(curr_fds);
+    if (g_pApp->m_const_params.measurement == TIME_BASED) {
+        // cycle through all set fds in the array (with wrap around to beginning)
+        for (int curr_fds = m_ioHandler.m_fd_min; !g_b_exit; curr_fds = g_fds_array[curr_fds]->next_fd)
+            client_send_then_receive(curr_fds);
+    } else {
+        uint64_t seqNo = 0;
+        uint64_t counterValid = 0;
+        uint64_t warmupObservations = s_user_params.warmup_obs;
+        uint64_t cooldownObservations = s_user_params.cooldown_obs;
+        uint64_t observationTarget = g_pApp->m_const_params.observation_test_count;
+        uint64_t stopCounting = warmupObservations + observationTarget + cooldownObservations;
+        const uint64_t replyEvery = g_pApp->m_const_params.reply_every;
+        const int SERVER_NO = 0; // TODO: should be one per server (as of 1/27/21 sockperf handles only one server)
+        TicksTime testStart;
+        TicksTime prevRxTime;
+        struct itimerval timer = {};
+
+        // cycle through all set fds in the array (with wrap around to beginning)
+        for (int curr_fds = m_ioHandler.m_fd_min; !g_b_exit; curr_fds = g_fds_array[curr_fds]->next_fd) {
+            client_send_then_receive(curr_fds);
+
+            // Packet not recorded, nothing to validate
+            if (g_receiveCount == seqNo) {
+                continue;
+            }
+
+            if(seqNo == 0) {
+                testStart = g_pPacketTimes->getTxTime(replyEvery); // first pong request packet
+            }
+
+            seqNo+= replyEvery;
+
+            // Validate observation
+            const TicksTime &txTime = g_pPacketTimes->getTxTime(seqNo);
+            const TicksTime &rxTime = g_pPacketTimes->getRxTimeArray(seqNo)[SERVER_NO];
+            if (txTime == TicksTime::TICKS0 || txTime < testStart ||
+                rxTime == TicksTime::TICKS0 || rxTime < prevRxTime) {
+                continue;
+            }
+            prevRxTime = rxTime;
+            counterValid++;
+
+            // Set timer to limit waiting on total observations
+            if(counterValid == warmupObservations && timer.it_value.tv_sec == 0) {
+                set_client_time_out_timer(&timer, testStart);
+                if (os_set_duration_timer(timer, client_sig_handler)) {
+                    exit_with_log("Failed setting test observation timer", SOCKPERF_ERR_FATAL);
+                }
+            }
+
+            if(counterValid == stopCounting) {
+                s_endTime.setNowNonInline();
+                log_msg("Test end (finished observation count)");
+                g_b_exit = true;
+            }
+        }
+    }
 }
 
 //------------------------------------------------------------------------------

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -196,7 +196,7 @@ void printHistogram(int binSize, std::map<int, int> &activeBins, int minValue, i
     int terminalWidth = 0;
     int scalingUnit = 0;
     int maxDisplayWidth = 0;
-    int maxStartBinDigits = getNumberOfDigits(maxValue - binSize);
+    int maxStartBinDigits = getNumberOfDigits(getStartOfRightOutlierBin());
     int maxEndBinDigits = getNumberOfDigits(maxValue);
     int whitespaceBeforeFrequencies = 2;
     int outlierMessageWidth = 11;
@@ -246,7 +246,7 @@ void printHistogram(int binSize, std::map<int, int> &activeBins, int minValue, i
     } else {
         log_msg("[Histogram] Display scaled to fit on screen (Key: '#' = up to %d samples)", scalingUnit);
     }
-    log_msg("%*s %*s", binsHeaderWidth, binsString.c_str(), frequencyHeaderWidth, freqString.c_str());
+    log_msg("%*s  %*s", binsHeaderWidth, binsString.c_str(), frequencyHeaderWidth, freqString.c_str());
     for(itr = activeBins.begin(); itr != activeBins.end(); ++itr) {
         frequency = itr->second;
         frequencyScaledDownCount = (frequency + scalingUnit - 1) / scalingUnit; // round up

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -401,7 +401,7 @@ void client_statistics(int serverNo, Message *pMsgRequest) {
                             totalRunTime.toDecimalUsec() / 1000000,
                             g_pApp->m_const_params.warmup_msec, sendCount, receiveCount, g_skipCount);
             } else {
-            log_msg_file2(f, "[Total Run] RunTime=%.3lf sec; Warm up packets=%" PRIu64
+                log_msg_file2(f, "[Total Run] RunTime=%.3lf sec; Warm up packets=%" PRIu64
                              "; SentMessages=%" PRIu64 "; ReceivedMessages=%" PRIu64
                              "; SkippedMessages=%" PRIu64 "",
                           totalRunTime.toDecimalUsec() / 1000000,

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -102,6 +102,7 @@ int set_affinity_list(os_thread_t thread, const char *cpu_list) {
         os_cpuset_t mycpuset;
         os_init_cpuset(&mycpuset);
 
+        // TODO: consider using sscanf for parsing below
         /* Parse cpu list */
         while (cur_buf) {
             errno = 0;

--- a/src/defs.h
+++ b/src/defs.h
@@ -132,7 +132,7 @@ const uint32_t TEST_FIRST_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC = 50;
 #define DEFAULT_CLIENT_WORK_WITH_SRV_NUM 1
 
 #define DEFAULT_TEST_DURATION 1 /* [sec] */
-#define DEFAULT_OBSERVATION_COUNT 0
+#define DEFAULT_TEST_NUMBER 0   /* [number of packets] */
 #define DEFAULT_MC_ADDR "0.0.0.0"
 #define DEFAULT_PORT 11111
 #define DEFAULT_IP_MTU 1500
@@ -164,7 +164,7 @@ const uint32_t TEST_FIRST_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC = 50;
 
 #define MAX_ARGV_SIZE 256
 #define MAX_DURATION 36000000
-#define MAX_OBSERVATIONS 100000000
+#define MAX_PACKET_NUMBER 100000000
 extern const int MAX_FDS_NUM;
 #define SOCK_BUFF_DEFAULT_SIZE 0
 #define DEFAULT_SELECT_TIMEOUT_MSEC 10
@@ -622,7 +622,7 @@ typedef enum {
 
 typedef enum {
     TIME_BASED = 1,
-    OBSERVATION_BASED
+    NUMBER_BASED
 } measurement_mode_t;
 
 typedef enum { // must be coordinated with s_fds_handle_desc in common.cpp
@@ -638,14 +638,14 @@ typedef enum { // must be coordinated with s_fds_handle_desc in common.cpp
 
 struct user_params_t {
     work_mode_t mode; // either client or server
-    measurement_mode_t measurement; // either time or observation
+    measurement_mode_t measurement; // either time or number
     struct in_addr rx_mc_if_addr;
     struct in_addr tx_mc_if_addr;
     struct in_addr mc_source_ip_addr;
     int msg_size;
     int msg_size_range;
     int sec_test_duration;
-    uint64_t observation_count_target;
+    uint64_t number_test_target;
     bool data_integrity;
     fd_block_handler_t fd_handler_type;
     unsigned int packetrate_stats_print_ratio;
@@ -662,8 +662,8 @@ struct user_params_t {
     unsigned int pre_warmup_wait;
     uint32_t cooldown_msec;
     uint32_t warmup_msec;
-    uint64_t cooldown_obs;
-    uint64_t warmup_obs;
+    uint64_t cooldown_num;
+    uint64_t warmup_num;
     bool is_vmarxfiltercb;
     bool is_vmazcopyread;
     TicksDuration cycleDuration;

--- a/src/defs.h
+++ b/src/defs.h
@@ -123,8 +123,8 @@ const uint32_t REPLY_EVERY_DEFAULT = 100;
 
 const uint32_t TEST_START_WARMUP_MSEC = 400;
 const uint32_t TEST_END_COOLDOWN_MSEC = 50;
-const uint32_t TEST_START_WARMUP_OBS = 8000;
-const uint32_t TEST_END_COOLDOWN_OBS = 1000;
+const uint64_t TEST_START_WARMUP_NUM = 8000;
+const uint64_t TEST_END_COOLDOWN_NUM = 1000;
 
 const uint32_t TEST_FIRST_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC = 50;
 #define TEST_ANY_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC (0.1)
@@ -645,7 +645,7 @@ struct user_params_t {
     int msg_size;
     int msg_size_range;
     int sec_test_duration;
-    uint32_t observation_test_count;
+    uint64_t observation_count_target;
     bool data_integrity;
     fd_block_handler_t fd_handler_type;
     unsigned int packetrate_stats_print_ratio;

--- a/src/defs.h
+++ b/src/defs.h
@@ -229,9 +229,6 @@ enum {
     OPT_FULL_RTT,                 // 44
     OPT_CI_SIG_LVL,               // 45
     OPT_HISTOGRAM,                // 46
-    OPT_HISTOGRAM_UPPER_RANGE,    // 47
-    OPT_HISTOGRAM_LOWER_RANGE,    // 48
-    OPT_HISTOGRAM_BIN_SIZE,       // 49
 #if defined(DEFINED_TLS)
     OPT_TLS
 #endif /* DEFINED_TLS */

--- a/src/defs.h
+++ b/src/defs.h
@@ -228,6 +228,10 @@ enum {
     OPT_UC_REUSEADDR,             // 43
     OPT_FULL_RTT,                 // 44
     OPT_CI_SIG_LVL,               // 45
+    OPT_HISTOGRAM,                // 46
+    OPT_HISTOGRAM_UPPER_RANGE,    // 47
+    OPT_HISTOGRAM_LOWER_RANGE,    // 48
+    OPT_HISTOGRAM_BIN_SIZE,       // 49
 #if defined(DEFINED_TLS)
     OPT_TLS
 #endif /* DEFINED_TLS */
@@ -686,6 +690,10 @@ struct user_params_t {
     bool b_stream;                   // client side only
     PlaybackVector *pPlaybackVector; // client side only
     uint32_t ci_significance_level;  // client side only
+    bool b_histogram;                // client side only
+    uint32_t histogram_lower_range;  // client side only
+    uint32_t histogram_upper_range;  // client side only
+    uint32_t histogram_bin_size;     // client side only
     struct sockaddr_in addr;
     int sock_type;
     bool tcp_nodelay;

--- a/src/defs.h
+++ b/src/defs.h
@@ -123,6 +123,8 @@ const uint32_t REPLY_EVERY_DEFAULT = 100;
 
 const uint32_t TEST_START_WARMUP_MSEC = 400;
 const uint32_t TEST_END_COOLDOWN_MSEC = 50;
+const uint32_t TEST_START_WARMUP_OBS = 8000;
+const uint32_t TEST_END_COOLDOWN_OBS = 1000;
 
 const uint32_t TEST_FIRST_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC = 50;
 #define TEST_ANY_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC (0.1)
@@ -130,6 +132,7 @@ const uint32_t TEST_FIRST_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC = 50;
 #define DEFAULT_CLIENT_WORK_WITH_SRV_NUM 1
 
 #define DEFAULT_TEST_DURATION 1 /* [sec] */
+#define DEFAULT_OBSERVATION_COUNT 0
 #define DEFAULT_MC_ADDR "0.0.0.0"
 #define DEFAULT_PORT 11111
 #define DEFAULT_IP_MTU 1500
@@ -160,6 +163,7 @@ const uint32_t TEST_FIRST_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC = 50;
 
 #define MAX_ARGV_SIZE 256
 #define MAX_DURATION 36000000
+#define MAX_OBSERVATIONS 100000000
 extern const int MAX_FDS_NUM;
 #define SOCK_BUFF_DEFAULT_SIZE 0
 #define DEFAULT_SELECT_TIMEOUT_MSEC 10
@@ -613,6 +617,11 @@ typedef enum {
     MODE_BRIDGE
 } work_mode_t;
 
+typedef enum {
+    TIME_BASED = 1,
+    OBSERVATION_BASED
+} measurement_mode_t;
+
 typedef enum { // must be coordinated with s_fds_handle_desc in common.cpp
     RECVFROM = 0,
     RECVFROMMUX,
@@ -625,13 +634,15 @@ typedef enum { // must be coordinated with s_fds_handle_desc in common.cpp
     FD_HANDLE_MAX } fd_block_handler_t;
 
 struct user_params_t {
-    work_mode_t mode; // either  client or server
+    work_mode_t mode; // either client or server
+    measurement_mode_t measurement; // either time or observation
     struct in_addr rx_mc_if_addr;
     struct in_addr tx_mc_if_addr;
     struct in_addr mc_source_ip_addr;
     int msg_size;
     int msg_size_range;
     int sec_test_duration;
+    uint32_t observation_test_count;
     bool data_integrity;
     fd_block_handler_t fd_handler_type;
     unsigned int packetrate_stats_print_ratio;
@@ -648,6 +659,8 @@ struct user_params_t {
     unsigned int pre_warmup_wait;
     uint32_t cooldown_msec;
     uint32_t warmup_msec;
+    uint64_t cooldown_obs;
+    uint64_t warmup_obs;
     bool is_vmarxfiltercb;
     bool is_vmazcopyread;
     TicksDuration cycleDuration;

--- a/src/defs.h
+++ b/src/defs.h
@@ -137,6 +137,7 @@ const uint32_t TEST_FIRST_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC = 50;
 #define DEFAULT_PORT 11111
 #define DEFAULT_IP_MTU 1500
 #define DEFAULT_IP_PAYLOAD_SZ (DEFAULT_IP_MTU - 28)
+#define DEFAULT_CI_SIG_LEVEL 99
 #define DUMMY_PORT 57341
 #define MAX_ACTIVE_FD_NUM                                                                          \
     1024 /* maximum number of active connection to the single TCP addr:port                        \
@@ -226,6 +227,7 @@ enum {
     OPT_RATE_LIMIT,               // 42
     OPT_UC_REUSEADDR,             // 43
     OPT_FULL_RTT,                 // 44
+    OPT_CI_SIG_LVL,               // 45
 #if defined(DEFINED_TLS)
     OPT_TLS
 #endif /* DEFINED_TLS */
@@ -683,6 +685,7 @@ struct user_params_t {
     bool increase_output_precision;  // client side only
     bool b_stream;                   // client side only
     PlaybackVector *pPlaybackVector; // client side only
+    uint32_t ci_significance_level;  // client side only
     struct sockaddr_in addr;
     int sock_type;
     bool tcp_nodelay;

--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -407,25 +407,10 @@ static int proc_mode_under_load(int id, int argc, const char **argv) {
           "Normal confidence interval significance level for stat reported. Values are between 0 and 100 "
           "exclusive (default 99). " },
         { OPT_HISTOGRAM,
-          AOPT_NOARG,
+          AOPT_OPTARG,
           aopt_set_literal(0),
           aopt_set_string("histogram"),
-          "Build histogram of latencies. " },
-        { OPT_HISTOGRAM_LOWER_RANGE,
-          AOPT_ARG,
-          aopt_set_literal(0),
-          aopt_set_string("h_lower_range_us"),
-          "Lower range in microseconds of interest for latency histogram (default 0). " },
-        { OPT_HISTOGRAM_UPPER_RANGE,
-          AOPT_ARG,
-          aopt_set_literal(0),
-          aopt_set_string("h_upper_range_us"),
-          "Upper range in microseconds of interest for latency histogram (default 2 secs). " },
-        { OPT_HISTOGRAM_BIN_SIZE,
-          AOPT_ARG,
-          aopt_set_literal(0),
-          aopt_set_string("h_bin_size_us"),
-          "Bin size in microseconds for latency histogram (default 10). " },
+          "Build histogram of latencies. Optional histogram arguments formated as binsize:lowerrange:upperrange " },
         { 0, AOPT_NOARG, aopt_set_literal(0), aopt_set_string(NULL), NULL }
     };
 
@@ -643,79 +628,63 @@ static int proc_mode_under_load(int id, int argc, const char **argv) {
 
         if (!rc && aopt_check(self_obj, OPT_HISTOGRAM)) {
             s_user_params.b_histogram = true;
-            if (!rc && aopt_check(self_obj, OPT_HISTOGRAM_LOWER_RANGE)) {
-                const char *optarg = aopt_value(self_obj, OPT_HISTOGRAM_LOWER_RANGE);
-                if (optarg) {
+            const char *optarg = aopt_value(self_obj, OPT_HISTOGRAM);
+
+            if (optarg && optarg[0]) {
+                char *buf = strdup(optarg);
+                char *cur_buf = buf;
+                char *cur_ptr = buf;
+                char *end_ptr = NULL;
+                int arg_index = 0;
+                int required_args = 3;
+                int parsed_arg [required_args]; // TODO: coello, should we make all 3 required?
+
+                /* Parse cpu list */
+                while (cur_buf) {
                     errno = 0;
-                    int value = strtol(optarg, NULL, 0);
-                    if (errno != 0 || value < 0) {
-                        log_msg("'--%s' Invalid lower range for histogram: %s",
-                            aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_LOWER_RANGE), optarg);
-                        rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                    if (*cur_ptr == '\0') {
+                        parsed_arg[arg_index] = strtol(cur_buf, &end_ptr, 0);
+                        if ((errno != 0) || (cur_buf == end_ptr)) {
+                            log_err("Invalid argument: %s", optarg);
+                            rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                            break;
+                        }
+                        cur_buf = NULL;
+                    } else if (*cur_ptr == ':') {
+                        *cur_ptr = '\0';
+                        parsed_arg[arg_index] = strtol(cur_buf, &end_ptr, 0);
+                        arg_index++;
+                        if ((errno != 0) || (cur_buf == end_ptr)) {
+                            log_err("Invalid argument: %s", optarg);
+                            rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                            break;
+                        }
+                        cur_buf = cur_ptr + 1;
+                        cur_ptr++;
+                        continue;
                     } else {
-                        s_user_params.histogram_lower_range = value;
+                        cur_ptr++;
+                        continue;
                     }
-                } else {
-                    log_msg("'--%s' Invalid value",
-                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_LOWER_RANGE));
+                }
+
+                if (arg_index != required_args - 1) {
+                    log_err("Invalid argument: %s "
+                            "Format should be binsize:lowerrange:upperrange", optarg);
                     rc = SOCKPERF_ERR_BAD_ARGUMENT;
                 }
-            }
+                s_user_params.histogram_bin_size = parsed_arg[0];
+                s_user_params.histogram_lower_range = parsed_arg[1];
+                s_user_params.histogram_upper_range = parsed_arg[2];
 
-            if (!rc && aopt_check(self_obj, OPT_HISTOGRAM_UPPER_RANGE)) {
-                const char *optarg = aopt_value(self_obj, OPT_HISTOGRAM_UPPER_RANGE);
-                if (optarg) {
-                    errno = 0;
-                    uint32_t value = strtol(optarg, NULL, 0);
-                    if (errno != 0 || value <= 0 || value < s_user_params.histogram_lower_range) {
-                        log_msg("'--%s' Invalid upper range for histogram: %s",
-                            aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_UPPER_RANGE), optarg);
-                        rc = SOCKPERF_ERR_BAD_ARGUMENT;
-                    } else {
-                        s_user_params.histogram_upper_range = value;
-                    }
-                } else {
-                    log_msg("'--%s' Invalid value",
-                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_UPPER_RANGE));
-                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                if (buf) {
+                    free(buf);
                 }
+            } else {
+                log_msg("'--%s' Invalid value",
+                    aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM));
+                rc = SOCKPERF_ERR_BAD_ARGUMENT;
             }
-
-            if (!rc && aopt_check(self_obj, OPT_HISTOGRAM_BIN_SIZE)) {
-                const char *optarg = aopt_value(self_obj, OPT_HISTOGRAM_BIN_SIZE);
-                if (optarg) {
-                    errno = 0;
-                    uint32_t value = strtol(optarg, NULL, 0);
-                    uint32_t range = s_user_params.histogram_upper_range - s_user_params.histogram_lower_range;
-
-                    if (errno != 0 || value <= 0 || value > range) {
-                        printf("tiny value: %" PRIu32 "\n", value);
-                        log_msg("'--%s' Invalid bin size for histogram: %s.",
-                            aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_BIN_SIZE), optarg);
-                        rc = SOCKPERF_ERR_BAD_ARGUMENT;
-                    } else {
-                        s_user_params.histogram_bin_size = value;
-                    }
-                } else {
-                    log_msg("'--%s' Invalid value",
-                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_BIN_SIZE));
-                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
-                }
-            }
-        }
-
-        if (!rc && aopt_check(self_obj, OPT_HISTOGRAM) == 0 &&
-            ( aopt_check(self_obj, OPT_HISTOGRAM_LOWER_RANGE) ||
-              aopt_check(self_obj, OPT_HISTOGRAM_UPPER_RANGE) ||
-              aopt_check(self_obj, OPT_HISTOGRAM_BIN_SIZE)
-            )
-           ) {
-            log_msg("Optional arguments '--%s' '--%s' '--%s' for histogram require flag '--%s'",
-                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_LOWER_RANGE),
-                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_UPPER_RANGE),
-                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_BIN_SIZE),
-                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM) );
-            rc = SOCKPERF_ERR_BAD_ARGUMENT;
         }
     }
 
@@ -813,25 +782,10 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
           "Normal confidence interval significance level for stat reported. Values are between 0 and 100 "
           "exclusive (default 99). " },
         { OPT_HISTOGRAM,
-          AOPT_NOARG,
+          AOPT_OPTARG,
           aopt_set_literal(0),
           aopt_set_string("histogram"),
-          "Build histogram of latencies. " },
-        { OPT_HISTOGRAM_LOWER_RANGE,
-          AOPT_ARG,
-          aopt_set_literal(0),
-          aopt_set_string("h_lower_range_us"),
-          "Lower range in microseconds of interest for latency histogram (default 0). " },
-        { OPT_HISTOGRAM_UPPER_RANGE,
-          AOPT_ARG,
-          aopt_set_literal(0),
-          aopt_set_string("h_upper_range_us"),
-          "Upper range in microseconds of interest for latency histogram (default 2 secs). " },
-        { OPT_HISTOGRAM_BIN_SIZE,
-          AOPT_ARG,
-          aopt_set_literal(0),
-          aopt_set_string("h_bin_size_us"),
-          "Bin size in microseconds for latency histogram (default 10). " },
+          "Build histogram of latencies. Optional histogram arguments formated as binsize:lowerrange:upperrange " },
         { 0, AOPT_NOARG, aopt_set_literal(0), aopt_set_string(NULL), NULL }
     };
 
@@ -1067,79 +1021,63 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
 
         if (!rc && aopt_check(self_obj, OPT_HISTOGRAM)) {
             s_user_params.b_histogram = true;
-            if (!rc && aopt_check(self_obj, OPT_HISTOGRAM_LOWER_RANGE)) {
-                const char *optarg = aopt_value(self_obj, OPT_HISTOGRAM_LOWER_RANGE);
-                if (optarg) {
+            const char *optarg = aopt_value(self_obj, OPT_HISTOGRAM);
+
+            if (optarg && optarg[0]) {
+                char *buf = strdup(optarg);
+                char *cur_buf = buf;
+                char *cur_ptr = buf;
+                char *end_ptr = NULL;
+                int arg_index = 0;
+                int required_args = 3;
+                int parsed_arg [required_args]; // TODO: coello, should we make all 3 required?
+
+                /* Parse cpu list */
+                while (cur_buf) {
                     errno = 0;
-                    int value = strtol(optarg, NULL, 0);
-                    if (errno != 0 || value < 0) {
-                        log_msg("'--%s' Invalid lower range for histogram: %s",
-                            aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_LOWER_RANGE), optarg);
-                        rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                    if (*cur_ptr == '\0') {
+                        parsed_arg[arg_index] = strtol(cur_buf, &end_ptr, 0);
+                        if ((errno != 0) || (cur_buf == end_ptr)) {
+                            log_err("Invalid argument: %s", optarg);
+                            rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                            break;
+                        }
+                        cur_buf = NULL;
+                    } else if (*cur_ptr == ':') {
+                        *cur_ptr = '\0';
+                        parsed_arg[arg_index] = strtol(cur_buf, &end_ptr, 0);
+                        arg_index++;
+                        if ((errno != 0) || (cur_buf == end_ptr)) {
+                            log_err("Invalid argument: %s", optarg);
+                            rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                            break;
+                        }
+                        cur_buf = cur_ptr + 1;
+                        cur_ptr++;
+                        continue;
                     } else {
-                        s_user_params.histogram_lower_range = value;
+                        cur_ptr++;
+                        continue;
                     }
-                } else {
-                    log_msg("'--%s' Invalid value",
-                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_LOWER_RANGE));
+                }
+
+                if (arg_index != required_args - 1) {
+                    log_err("Invalid argument: %s "
+                            "Format should be binsize:lowerrange:upperrange", optarg);
                     rc = SOCKPERF_ERR_BAD_ARGUMENT;
                 }
-            }
+                s_user_params.histogram_bin_size = parsed_arg[0];
+                s_user_params.histogram_lower_range = parsed_arg[1];
+                s_user_params.histogram_upper_range = parsed_arg[2];
 
-            if (!rc && aopt_check(self_obj, OPT_HISTOGRAM_UPPER_RANGE)) {
-                const char *optarg = aopt_value(self_obj, OPT_HISTOGRAM_UPPER_RANGE);
-                if (optarg) {
-                    errno = 0;
-                    uint32_t value = strtol(optarg, NULL, 0);
-                    if (errno != 0 || value <= 0 || value < s_user_params.histogram_lower_range) {
-                        log_msg("'--%s' Invalid upper range for histogram: %s",
-                            aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_UPPER_RANGE), optarg);
-                        rc = SOCKPERF_ERR_BAD_ARGUMENT;
-                    } else {
-                        s_user_params.histogram_upper_range = value;
-                    }
-                } else {
-                    log_msg("'--%s' Invalid value",
-                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_UPPER_RANGE));
-                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                if (buf) {
+                    free(buf);
                 }
+            } else {
+                log_msg("'--%s' Invalid value",
+                    aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM));
+                rc = SOCKPERF_ERR_BAD_ARGUMENT;
             }
-
-            if (!rc && aopt_check(self_obj, OPT_HISTOGRAM_BIN_SIZE)) {
-                const char *optarg = aopt_value(self_obj, OPT_HISTOGRAM_BIN_SIZE);
-                if (optarg) {
-                    errno = 0;
-                    uint32_t value = strtol(optarg, NULL, 0);
-                    uint32_t range = s_user_params.histogram_upper_range - s_user_params.histogram_lower_range;
-
-                    if (errno != 0 || value <= 0 || value > range) {
-                        printf("tiny value: %" PRIu32 "\n", value);
-                        log_msg("'--%s' Invalid bin size for histogram: %s.",
-                            aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_BIN_SIZE), optarg);
-                        rc = SOCKPERF_ERR_BAD_ARGUMENT;
-                    } else {
-                        s_user_params.histogram_bin_size = value;
-                    }
-                } else {
-                    log_msg("'--%s' Invalid value",
-                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_BIN_SIZE));
-                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
-                }
-            }
-        }
-
-        if (!rc && aopt_check(self_obj, OPT_HISTOGRAM) == 0 &&
-            ( aopt_check(self_obj, OPT_HISTOGRAM_LOWER_RANGE) ||
-              aopt_check(self_obj, OPT_HISTOGRAM_UPPER_RANGE) ||
-              aopt_check(self_obj, OPT_HISTOGRAM_BIN_SIZE)
-            )
-           ) {
-            log_msg("Optional arguments '--%s' '--%s' '--%s' for histogram require flag '--%s'",
-                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_LOWER_RANGE),
-                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_UPPER_RANGE),
-                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_BIN_SIZE),
-                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM) );
-            rc = SOCKPERF_ERR_BAD_ARGUMENT;
         }
     }
 
@@ -1481,25 +1419,10 @@ static int proc_mode_playback(int id, int argc, const char **argv) {
           "Normal confidence interval significance level for stat reported. Values are between 0 and 100 "
           "exclusive (default 99). " },
         { OPT_HISTOGRAM,
-          AOPT_NOARG,
+          AOPT_OPTARG,
           aopt_set_literal(0),
           aopt_set_string("histogram"),
-          "Build histogram of latencies. " },
-        { OPT_HISTOGRAM_LOWER_RANGE,
-          AOPT_ARG,
-          aopt_set_literal(0),
-          aopt_set_string("h_lower_range_us"),
-          "Lower range in microseconds of interest for latency histogram (default 0). " },
-        { OPT_HISTOGRAM_UPPER_RANGE,
-          AOPT_ARG,
-          aopt_set_literal(0),
-          aopt_set_string("h_upper_range_us"),
-          "Upper range in microseconds of interest for latency histogram (default 2 secs). " },
-        { OPT_HISTOGRAM_BIN_SIZE,
-          AOPT_ARG,
-          aopt_set_literal(0),
-          aopt_set_string("h_bin_size_us"),
-          "Bin size in microseconds for latency histogram (default 10). " },
+          "Build histogram of latencies. Optional histogram arguments formated as binsize:lowerrange:upperrange " },
         { 0, AOPT_NOARG, aopt_set_literal(0), aopt_set_string(NULL), NULL }
     };
 
@@ -1593,79 +1516,63 @@ static int proc_mode_playback(int id, int argc, const char **argv) {
 
         if (!rc && aopt_check(self_obj, OPT_HISTOGRAM)) {
             s_user_params.b_histogram = true;
-            if (!rc && aopt_check(self_obj, OPT_HISTOGRAM_LOWER_RANGE)) {
-                const char *optarg = aopt_value(self_obj, OPT_HISTOGRAM_LOWER_RANGE);
-                if (optarg) {
+            const char *optarg = aopt_value(self_obj, OPT_HISTOGRAM);
+
+            if (optarg && optarg[0]) {
+                char *buf = strdup(optarg);
+                char *cur_buf = buf;
+                char *cur_ptr = buf;
+                char *end_ptr = NULL;
+                int arg_index = 0;
+                int required_args = 3;
+                int parsed_arg [required_args]; // TODO: coello, should we make all 3 required?
+
+                /* Parse cpu list */
+                while (cur_buf) {
                     errno = 0;
-                    int value = strtol(optarg, NULL, 0);
-                    if (errno != 0 || value < 0) {
-                        log_msg("'--%s' Invalid lower range for histogram: %s",
-                            aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_LOWER_RANGE), optarg);
-                        rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                    if (*cur_ptr == '\0') {
+                        parsed_arg[arg_index] = strtol(cur_buf, &end_ptr, 0);
+                        if ((errno != 0) || (cur_buf == end_ptr)) {
+                            log_err("Invalid argument: %s", optarg);
+                            rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                            break;
+                        }
+                        cur_buf = NULL;
+                    } else if (*cur_ptr == ':') {
+                        *cur_ptr = '\0';
+                        parsed_arg[arg_index] = strtol(cur_buf, &end_ptr, 0);
+                        arg_index++;
+                        if ((errno != 0) || (cur_buf == end_ptr)) {
+                            log_err("Invalid argument: %s", optarg);
+                            rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                            break;
+                        }
+                        cur_buf = cur_ptr + 1;
+                        cur_ptr++;
+                        continue;
                     } else {
-                        s_user_params.histogram_lower_range = value;
+                        cur_ptr++;
+                        continue;
                     }
-                } else {
-                    log_msg("'--%s' Invalid value",
-                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_LOWER_RANGE));
+                }
+
+                if (arg_index != required_args - 1) {
+                    log_err("Invalid argument: %s "
+                            "Format should be binsize:lowerrange:upperrange", optarg);
                     rc = SOCKPERF_ERR_BAD_ARGUMENT;
                 }
-            }
+                s_user_params.histogram_bin_size = parsed_arg[0];
+                s_user_params.histogram_lower_range = parsed_arg[1];
+                s_user_params.histogram_upper_range = parsed_arg[2];
 
-            if (!rc && aopt_check(self_obj, OPT_HISTOGRAM_UPPER_RANGE)) {
-                const char *optarg = aopt_value(self_obj, OPT_HISTOGRAM_UPPER_RANGE);
-                if (optarg) {
-                    errno = 0;
-                    uint32_t value = strtol(optarg, NULL, 0);
-                    if (errno != 0 || value <= 0 || value < s_user_params.histogram_lower_range) {
-                        log_msg("'--%s' Invalid upper range for histogram: %s",
-                            aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_UPPER_RANGE), optarg);
-                        rc = SOCKPERF_ERR_BAD_ARGUMENT;
-                    } else {
-                        s_user_params.histogram_upper_range = value;
-                    }
-                } else {
-                    log_msg("'--%s' Invalid value",
-                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_UPPER_RANGE));
-                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                if (buf) {
+                    free(buf);
                 }
+            } else {
+                log_msg("'--%s' Invalid value",
+                    aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM));
+                rc = SOCKPERF_ERR_BAD_ARGUMENT;
             }
-
-            if (!rc && aopt_check(self_obj, OPT_HISTOGRAM_BIN_SIZE)) {
-                const char *optarg = aopt_value(self_obj, OPT_HISTOGRAM_BIN_SIZE);
-                if (optarg) {
-                    errno = 0;
-                    uint32_t value = strtol(optarg, NULL, 0);
-                    uint32_t range = s_user_params.histogram_upper_range - s_user_params.histogram_lower_range;
-
-                    if (errno != 0 || value <= 0 || value > range) {
-                        printf("tiny value: %" PRIu32 "\n", value);
-                        log_msg("'--%s' Invalid bin size for histogram: %s.",
-                            aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_BIN_SIZE), optarg);
-                        rc = SOCKPERF_ERR_BAD_ARGUMENT;
-                    } else {
-                        s_user_params.histogram_bin_size = value;
-                    }
-                } else {
-                    log_msg("'--%s' Invalid value",
-                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_BIN_SIZE));
-                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
-                }
-            }
-        }
-
-        if (!rc && aopt_check(self_obj, OPT_HISTOGRAM) == 0 &&
-            ( aopt_check(self_obj, OPT_HISTOGRAM_LOWER_RANGE) ||
-              aopt_check(self_obj, OPT_HISTOGRAM_UPPER_RANGE) ||
-              aopt_check(self_obj, OPT_HISTOGRAM_BIN_SIZE)
-            )
-           ) {
-            log_msg("Optional arguments '--%s' '--%s' '--%s' for histogram require flag '--%s'",
-                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_LOWER_RANGE),
-                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_UPPER_RANGE),
-                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_BIN_SIZE),
-                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM) );
-            rc = SOCKPERF_ERR_BAD_ARGUMENT;
         }
     }
 

--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -841,7 +841,7 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
                     rc = SOCKPERF_ERR_BAD_ARGUMENT;
                 } else {
                     s_user_params.measurement = OBSERVATION_BASED;
-                    s_user_params.observation_test_count = value;
+                    s_user_params.observation_count_target = value;
                 }
             } else {
                 log_msg("'-%c' Invalid value", 'n');
@@ -2478,7 +2478,7 @@ void set_defaults() {
     s_user_params.tx_mc_if_addr.s_addr = htonl(INADDR_ANY);
     s_user_params.mc_source_ip_addr.s_addr = htonl(INADDR_ANY);
     s_user_params.sec_test_duration = DEFAULT_TEST_DURATION;
-    s_user_params.observation_test_count = DEFAULT_OBSERVATION_COUNT;
+    s_user_params.observation_count_target = DEFAULT_OBSERVATION_COUNT;
     s_user_params.client_bind_info.sin_family = AF_INET;
     s_user_params.client_bind_info.sin_addr.s_addr = INADDR_ANY;
     s_user_params.client_bind_info.sin_port = 0;
@@ -3670,7 +3670,7 @@ with_sock_accl = %d \n\t\
 msg_size = %d \n\t\
 msg_size_range = %d \n\t\
 sec_test_duration = %d \n\t\
-observation_test_count = %d \n\t\
+observation_count_target = %lu \n\t\
 data_integrity = %d \n\t\
 packetrate_stats_print_ratio = %d \n\t\
 burst_size = %d \n\t\
@@ -3708,7 +3708,7 @@ tos = %d \n\t\
 packet pace limit = %d",
             s_user_params.mode, s_user_params.measurement, s_user_params.withsock_accl,
             s_user_params.msg_size, s_user_params.msg_size_range, s_user_params.sec_test_duration,
-            s_user_params.observation_test_count, s_user_params.data_integrity,
+            s_user_params.observation_count_target, s_user_params.data_integrity,
             s_user_params.packetrate_stats_print_ratio, s_user_params.burst_size,
             s_user_params.packetrate_stats_print_details, s_user_params.fd_handler_type,
             s_user_params.mthread_server, s_user_params.sock_buff_size, s_user_params.threads_num,

--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -832,42 +832,52 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
     /* Set command line specific values */
     if (!rc && self_obj) {
         if (!rc && aopt_check(self_obj, 'n')) {
-            const char *optarg = aopt_value(self_obj, 'n');
-            if (optarg) {
-                errno = 0;
-                int value = strtol(optarg, NULL, 0);
-                if (errno != 0 || value <= 0 || value > MAX_OBSERVATIONS) {
-                    log_msg("'-%c' Invalid observations: %s", 'n', optarg);
-                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+            if (!aopt_check(self_obj, 't') && !aopt_check(self_obj, OPT_MPS)) {
+                const char *optarg = aopt_value(self_obj, 'n');
+                if (optarg) {
+                    errno = 0;
+                    int value = strtol(optarg, NULL, 0);
+                    if (errno != 0 || value <= 0 || value > MAX_OBSERVATIONS) {
+                        log_msg("'-%c' Invalid observations: %s", 'n', optarg);
+                        rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                    } else {
+                        s_user_params.measurement = OBSERVATION_BASED;
+                        s_user_params.observation_count_target = value;
+                    }
                 } else {
-                    s_user_params.measurement = OBSERVATION_BASED;
-                    s_user_params.observation_count_target = value;
+                    log_msg("'-%c' Invalid value", 'n');
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
                 }
             } else {
-                log_msg("'-%c' Invalid value", 'n');
+                log_msg("-n conflicts with -t,--mps options");
                 rc = SOCKPERF_ERR_BAD_ARGUMENT;
             }
         }
 
         if (!rc && aopt_check(self_obj, 't')) {
-            const char *optarg = aopt_value(self_obj, 't');
-            if (optarg) {
-                errno = 0;
-                int value = strtol(optarg, NULL, 0);
-                if (errno != 0 || value <= 0 || value > MAX_DURATION) {
-                    log_msg("'-%c' Invalid duration: %s", 't', optarg);
-                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
-                } else {
-                    if (s_user_params.measurement == OBSERVATION_BASED) {
-                        log_msg("Can't be both observation and time based");
+            if (!aopt_check(self_obj, 'n')) {
+                const char *optarg = aopt_value(self_obj, 't');
+                if (optarg) {
+                    errno = 0;
+                    int value = strtol(optarg, NULL, 0);
+                    if (errno != 0 || value <= 0 || value > MAX_DURATION) {
+                        log_msg("'-%c' Invalid duration: %s", 't', optarg);
                         rc = SOCKPERF_ERR_BAD_ARGUMENT;
                     } else {
-                        s_user_params.measurement = TIME_BASED;
-                        s_user_params.sec_test_duration = value;
+                        if (s_user_params.measurement == OBSERVATION_BASED) {
+                            log_msg("Can't be both observation and time based");
+                            rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                        } else {
+                            s_user_params.measurement = TIME_BASED;
+                            s_user_params.sec_test_duration = value;
+                        }
                     }
+                } else {
+                    log_msg("'-%c' Invalid value", 't');
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
                 }
             } else {
-                log_msg("'-%c' Invalid value", 't');
+                log_msg("-t conflicts with -n option");
                 rc = SOCKPERF_ERR_BAD_ARGUMENT;
             }
         }

--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -138,7 +138,7 @@ static const struct app_modes {
         aopt_set_string("ul"), "Run " MODULE_NAME " client for latency under load test." },
       { proc_mode_ping_pong,   "ping-pong",
         aopt_set_string("pp"), "Run " MODULE_NAME " client for latency test in ping pong mode." },
-      { proc_mode_playback, "playback",
+      { proc_mode_playback,    "playback",
         aopt_set_string("pb"), "Run " MODULE_NAME " client for latency test using playback of predefined "
                                "traffic, based on timeline and message size." },
       { proc_mode_throughput,  "throughput",

--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -635,13 +635,10 @@ static int proc_mode_under_load(int id, int argc, const char **argv) {
                 int required_args = 3;
 
                 /* Parse histogram options list */
-                long bin_size, lower_range, upper_range;
                 char suffix; //< needed to check for garbage at the end
-                if (sscanf(optarg, "%ld:%ld:%ld%c", &bin_size, &lower_range, &upper_range, &suffix) == required_args) {
-                    s_user_params.histogram_bin_size = bin_size;
-                    s_user_params.histogram_lower_range = lower_range;
-                    s_user_params.histogram_upper_range = upper_range;
-                } else {
+                if (sscanf(optarg, "%" PRIu32 ":%" PRIu32 ":%" PRIu32 "%c",
+                    &s_user_params.histogram_bin_size, &s_user_params.histogram_lower_range,
+                    &s_user_params.histogram_upper_range, &suffix) != required_args) {
                     log_err("Invalid argument: %s "
                             "Format should be binsize:lowerrange:upperrange", optarg);
                     rc = SOCKPERF_ERR_BAD_ARGUMENT;
@@ -1003,13 +1000,10 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
                 int required_args = 3;
 
                 /* Parse histogram options list */
-                long bin_size, lower_range, upper_range;
                 char suffix; //< needed to check for garbage at the end
-                if (sscanf(optarg, "%ld:%ld:%ld%c", &bin_size, &lower_range, &upper_range, &suffix) == required_args) {
-                    s_user_params.histogram_bin_size = bin_size;
-                    s_user_params.histogram_lower_range = lower_range;
-                    s_user_params.histogram_upper_range = upper_range;
-                } else {
+                if (sscanf(optarg, "%" PRIu32 ":%" PRIu32 ":%" PRIu32 "%c",
+                    &s_user_params.histogram_bin_size, &s_user_params.histogram_lower_range,
+                    &s_user_params.histogram_upper_range, &suffix) != required_args) {
                     log_err("Invalid argument: %s "
                             "Format should be binsize:lowerrange:upperrange", optarg);
                     rc = SOCKPERF_ERR_BAD_ARGUMENT;
@@ -1468,13 +1462,10 @@ static int proc_mode_playback(int id, int argc, const char **argv) {
                 int required_args = 3;
 
                 /* Parse histogram options list */
-                long bin_size, lower_range, upper_range;
                 char suffix; //< needed to check for garbage at the end
-                if (sscanf(optarg, "%ld:%ld:%ld%c", &bin_size, &lower_range, &upper_range, &suffix) == required_args) {
-                    s_user_params.histogram_bin_size = bin_size;
-                    s_user_params.histogram_lower_range = lower_range;
-                    s_user_params.histogram_upper_range = upper_range;
-                } else {
+                if (sscanf(optarg, "%" PRIu32 ":%" PRIu32 ":%" PRIu32 "%c",
+                    &s_user_params.histogram_bin_size, &s_user_params.histogram_lower_range,
+                    &s_user_params.histogram_upper_range, &suffix) != required_args) {
                     log_err("Invalid argument: %s "
                             "Format should be binsize:lowerrange:upperrange", optarg);
                     rc = SOCKPERF_ERR_BAD_ARGUMENT;

--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -407,10 +407,10 @@ static int proc_mode_under_load(int id, int argc, const char **argv) {
           "Normal confidence interval significance level for stat reported. Values are between 0 and 100 "
           "exclusive (default 99). " },
         { OPT_HISTOGRAM,
-          AOPT_OPTARG,
+          AOPT_ARG,
           aopt_set_literal(0),
           aopt_set_string("histogram"),
-          "Build histogram of latencies. Optional histogram arguments formated as binsize:lowerrange:upperrange " },
+          "Build histogram of latencies. Histogram arguments formated as binsize:lowerrange:upperrange " },
         { 0, AOPT_NOARG, aopt_set_literal(0), aopt_set_string(NULL), NULL }
     };
 
@@ -632,50 +632,20 @@ static int proc_mode_under_load(int id, int argc, const char **argv) {
 
             if (optarg && optarg[0]) {
                 char *buf = strdup(optarg);
-                char *cur_buf = buf;
-                char *cur_ptr = buf;
-                char *end_ptr = NULL;
-                int arg_index = 0;
                 int required_args = 3;
-                int parsed_arg [required_args]; // TODO: coello, should we make all 3 required?
 
-                /* Parse cpu list */
-                while (cur_buf) {
-                    errno = 0;
-                    if (*cur_ptr == '\0') {
-                        parsed_arg[arg_index] = strtol(cur_buf, &end_ptr, 0);
-                        if ((errno != 0) || (cur_buf == end_ptr)) {
-                            log_err("Invalid argument: %s", optarg);
-                            rc = SOCKPERF_ERR_BAD_ARGUMENT;
-                            break;
-                        }
-                        cur_buf = NULL;
-                    } else if (*cur_ptr == ':') {
-                        *cur_ptr = '\0';
-                        parsed_arg[arg_index] = strtol(cur_buf, &end_ptr, 0);
-                        arg_index++;
-                        if ((errno != 0) || (cur_buf == end_ptr)) {
-                            log_err("Invalid argument: %s", optarg);
-                            rc = SOCKPERF_ERR_BAD_ARGUMENT;
-                            break;
-                        }
-                        cur_buf = cur_ptr + 1;
-                        cur_ptr++;
-                        continue;
-                    } else {
-                        cur_ptr++;
-                        continue;
-                    }
-                }
-
-                if (arg_index != required_args - 1) {
+                /* Parse histogram options list */
+                long bin_size, lower_range, upper_range;
+                char suffix; //< needed to check for garbage at the end
+                if (sscanf(optarg, "%ld:%ld:%ld%c", &bin_size, &lower_range, &upper_range, &suffix) == required_args) {
+                    s_user_params.histogram_bin_size = bin_size;
+                    s_user_params.histogram_lower_range = lower_range;
+                    s_user_params.histogram_upper_range = upper_range;
+                } else {
                     log_err("Invalid argument: %s "
                             "Format should be binsize:lowerrange:upperrange", optarg);
                     rc = SOCKPERF_ERR_BAD_ARGUMENT;
                 }
-                s_user_params.histogram_bin_size = parsed_arg[0];
-                s_user_params.histogram_lower_range = parsed_arg[1];
-                s_user_params.histogram_upper_range = parsed_arg[2];
 
                 if (buf) {
                     free(buf);
@@ -782,10 +752,10 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
           "Normal confidence interval significance level for stat reported. Values are between 0 and 100 "
           "exclusive (default 99). " },
         { OPT_HISTOGRAM,
-          AOPT_OPTARG,
+          AOPT_ARG,
           aopt_set_literal(0),
           aopt_set_string("histogram"),
-          "Build histogram of latencies. Optional histogram arguments formated as binsize:lowerrange:upperrange " },
+          "Build histogram of latencies. Histogram arguments formated as binsize:lowerrange:upperrange " },
         { 0, AOPT_NOARG, aopt_set_literal(0), aopt_set_string(NULL), NULL }
     };
 
@@ -1030,50 +1000,20 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
 
             if (optarg && optarg[0]) {
                 char *buf = strdup(optarg);
-                char *cur_buf = buf;
-                char *cur_ptr = buf;
-                char *end_ptr = NULL;
-                int arg_index = 0;
                 int required_args = 3;
-                int parsed_arg [required_args]; // TODO: coello, should we make all 3 required?
 
-                /* Parse cpu list */
-                while (cur_buf) {
-                    errno = 0;
-                    if (*cur_ptr == '\0') {
-                        parsed_arg[arg_index] = strtol(cur_buf, &end_ptr, 0);
-                        if ((errno != 0) || (cur_buf == end_ptr)) {
-                            log_err("Invalid argument: %s", optarg);
-                            rc = SOCKPERF_ERR_BAD_ARGUMENT;
-                            break;
-                        }
-                        cur_buf = NULL;
-                    } else if (*cur_ptr == ':') {
-                        *cur_ptr = '\0';
-                        parsed_arg[arg_index] = strtol(cur_buf, &end_ptr, 0);
-                        arg_index++;
-                        if ((errno != 0) || (cur_buf == end_ptr)) {
-                            log_err("Invalid argument: %s", optarg);
-                            rc = SOCKPERF_ERR_BAD_ARGUMENT;
-                            break;
-                        }
-                        cur_buf = cur_ptr + 1;
-                        cur_ptr++;
-                        continue;
-                    } else {
-                        cur_ptr++;
-                        continue;
-                    }
-                }
-
-                if (arg_index != required_args - 1) {
+                /* Parse histogram options list */
+                long bin_size, lower_range, upper_range;
+                char suffix; //< needed to check for garbage at the end
+                if (sscanf(optarg, "%ld:%ld:%ld%c", &bin_size, &lower_range, &upper_range, &suffix) == required_args) {
+                    s_user_params.histogram_bin_size = bin_size;
+                    s_user_params.histogram_lower_range = lower_range;
+                    s_user_params.histogram_upper_range = upper_range;
+                } else {
                     log_err("Invalid argument: %s "
                             "Format should be binsize:lowerrange:upperrange", optarg);
                     rc = SOCKPERF_ERR_BAD_ARGUMENT;
                 }
-                s_user_params.histogram_bin_size = parsed_arg[0];
-                s_user_params.histogram_lower_range = parsed_arg[1];
-                s_user_params.histogram_upper_range = parsed_arg[2];
 
                 if (buf) {
                     free(buf);
@@ -1424,10 +1364,10 @@ static int proc_mode_playback(int id, int argc, const char **argv) {
           "Normal confidence interval significance level for stat reported. Values are between 0 and 100 "
           "exclusive (default 99). " },
         { OPT_HISTOGRAM,
-          AOPT_OPTARG,
+          AOPT_ARG,
           aopt_set_literal(0),
           aopt_set_string("histogram"),
-          "Build histogram of latencies. Optional histogram arguments formated as binsize:lowerrange:upperrange " },
+          "Build histogram of latencies. Histogram arguments formated as binsize:lowerrange:upperrange " },
         { 0, AOPT_NOARG, aopt_set_literal(0), aopt_set_string(NULL), NULL }
     };
 
@@ -1525,50 +1465,20 @@ static int proc_mode_playback(int id, int argc, const char **argv) {
 
             if (optarg && optarg[0]) {
                 char *buf = strdup(optarg);
-                char *cur_buf = buf;
-                char *cur_ptr = buf;
-                char *end_ptr = NULL;
-                int arg_index = 0;
                 int required_args = 3;
-                int parsed_arg [required_args]; // TODO: coello, should we make all 3 required?
 
-                /* Parse cpu list */
-                while (cur_buf) {
-                    errno = 0;
-                    if (*cur_ptr == '\0') {
-                        parsed_arg[arg_index] = strtol(cur_buf, &end_ptr, 0);
-                        if ((errno != 0) || (cur_buf == end_ptr)) {
-                            log_err("Invalid argument: %s", optarg);
-                            rc = SOCKPERF_ERR_BAD_ARGUMENT;
-                            break;
-                        }
-                        cur_buf = NULL;
-                    } else if (*cur_ptr == ':') {
-                        *cur_ptr = '\0';
-                        parsed_arg[arg_index] = strtol(cur_buf, &end_ptr, 0);
-                        arg_index++;
-                        if ((errno != 0) || (cur_buf == end_ptr)) {
-                            log_err("Invalid argument: %s", optarg);
-                            rc = SOCKPERF_ERR_BAD_ARGUMENT;
-                            break;
-                        }
-                        cur_buf = cur_ptr + 1;
-                        cur_ptr++;
-                        continue;
-                    } else {
-                        cur_ptr++;
-                        continue;
-                    }
-                }
-
-                if (arg_index != required_args - 1) {
+                /* Parse histogram options list */
+                long bin_size, lower_range, upper_range;
+                char suffix; //< needed to check for garbage at the end
+                if (sscanf(optarg, "%ld:%ld:%ld%c", &bin_size, &lower_range, &upper_range, &suffix) == required_args) {
+                    s_user_params.histogram_bin_size = bin_size;
+                    s_user_params.histogram_lower_range = lower_range;
+                    s_user_params.histogram_upper_range = upper_range;
+                } else {
                     log_err("Invalid argument: %s "
                             "Format should be binsize:lowerrange:upperrange", optarg);
                     rc = SOCKPERF_ERR_BAD_ARGUMENT;
                 }
-                s_user_params.histogram_bin_size = parsed_arg[0];
-                s_user_params.histogram_lower_range = parsed_arg[1];
-                s_user_params.histogram_upper_range = parsed_arg[2];
 
                 if (buf) {
                     free(buf);
@@ -3563,7 +3473,7 @@ int bringup(const int *p_daemonize) {
                                   10 * s_user_params.reply_every; // + 10 replies for safety
         _maxSequenceNo += s_user_params.burst_size; // needed for the case burst_size > mps
 
-        if(s_user_params.measurement == NUMBER_BASED) {
+        if (s_user_params.measurement == NUMBER_BASED) {
             // override to reach max packet count during number based
             _maxSequenceNo = TEST_START_WARMUP_NUM + MAX_PACKET_NUMBER + TEST_END_COOLDOWN_NUM;
         }

--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -406,6 +406,26 @@ static int proc_mode_under_load(int id, int argc, const char **argv) {
           aopt_set_string("ci_sig_level"),
           "Normal confidence interval significance level for stat reported. Values are between 0 and 100 "
           "exclusive (default 99). " },
+        { OPT_HISTOGRAM,
+          AOPT_NOARG,
+          aopt_set_literal(0),
+          aopt_set_string("histogram"),
+          "Build histogram of latencies. " },
+        { OPT_HISTOGRAM_LOWER_RANGE,
+          AOPT_ARG,
+          aopt_set_literal(0),
+          aopt_set_string("h_lower_range_us"),
+          "Lower range in microseconds of interest for latency histogram (default 0). " },
+        { OPT_HISTOGRAM_UPPER_RANGE,
+          AOPT_ARG,
+          aopt_set_literal(0),
+          aopt_set_string("h_upper_range_us"),
+          "Upper range in microseconds of interest for latency histogram (default 2 secs). " },
+        { OPT_HISTOGRAM_BIN_SIZE,
+          AOPT_ARG,
+          aopt_set_literal(0),
+          aopt_set_string("h_bin_size_us"),
+          "Bin size in microseconds for latency histogram (default 10). " },
         { 0, AOPT_NOARG, aopt_set_literal(0), aopt_set_string(NULL), NULL }
     };
 
@@ -620,6 +640,83 @@ static int proc_mode_under_load(int id, int argc, const char **argv) {
                 rc = SOCKPERF_ERR_BAD_ARGUMENT;
             }
         }
+
+        if (!rc && aopt_check(self_obj, OPT_HISTOGRAM)) {
+            s_user_params.b_histogram = true;
+            if (!rc && aopt_check(self_obj, OPT_HISTOGRAM_LOWER_RANGE)) {
+                const char *optarg = aopt_value(self_obj, OPT_HISTOGRAM_LOWER_RANGE);
+                if (optarg) {
+                    errno = 0;
+                    int value = strtol(optarg, NULL, 0);
+                    if (errno != 0 || value < 0) {
+                        log_msg("'--%s' Invalid lower range for histogram: %s",
+                            aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_LOWER_RANGE), optarg);
+                        rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                    } else {
+                        s_user_params.histogram_lower_range = value;
+                    }
+                } else {
+                    log_msg("'--%s' Invalid value",
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_LOWER_RANGE));
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                }
+            }
+
+            if (!rc && aopt_check(self_obj, OPT_HISTOGRAM_UPPER_RANGE)) {
+                const char *optarg = aopt_value(self_obj, OPT_HISTOGRAM_UPPER_RANGE);
+                if (optarg) {
+                    errno = 0;
+                    uint32_t value = strtol(optarg, NULL, 0);
+                    if (errno != 0 || value <= 0 || value < s_user_params.histogram_lower_range) {
+                        log_msg("'--%s' Invalid upper range for histogram: %s",
+                            aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_UPPER_RANGE), optarg);
+                        rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                    } else {
+                        s_user_params.histogram_upper_range = value;
+                    }
+                } else {
+                    log_msg("'--%s' Invalid value",
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_UPPER_RANGE));
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                }
+            }
+
+            if (!rc && aopt_check(self_obj, OPT_HISTOGRAM_BIN_SIZE)) {
+                const char *optarg = aopt_value(self_obj, OPT_HISTOGRAM_BIN_SIZE);
+                if (optarg) {
+                    errno = 0;
+                    uint32_t value = strtol(optarg, NULL, 0);
+                    uint32_t range = s_user_params.histogram_upper_range - s_user_params.histogram_lower_range;
+
+                    if (errno != 0 || value <= 0 || value > range) {
+                        printf("tiny value: %" PRIu32 "\n", value);
+                        log_msg("'--%s' Invalid bin size for histogram: %s.",
+                            aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_BIN_SIZE), optarg);
+                        rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                    } else {
+                        s_user_params.histogram_bin_size = value;
+                    }
+                } else {
+                    log_msg("'--%s' Invalid value",
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_BIN_SIZE));
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                }
+            }
+        }
+
+        if (!rc && aopt_check(self_obj, OPT_HISTOGRAM) == 0 &&
+            ( aopt_check(self_obj, OPT_HISTOGRAM_LOWER_RANGE) ||
+              aopt_check(self_obj, OPT_HISTOGRAM_UPPER_RANGE) ||
+              aopt_check(self_obj, OPT_HISTOGRAM_BIN_SIZE)
+            )
+           ) {
+            log_msg("Optional arguments '--%s' '--%s' '--%s' for histogram require flag '--%s'",
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_LOWER_RANGE),
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_UPPER_RANGE),
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_BIN_SIZE),
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM) );
+            rc = SOCKPERF_ERR_BAD_ARGUMENT;
+        }
     }
 
     if (rc) {
@@ -715,6 +812,26 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
           aopt_set_string("ci_sig_level"),
           "Normal confidence interval significance level for stat reported. Values are between 0 and 100 "
           "exclusive (default 99). " },
+        { OPT_HISTOGRAM,
+          AOPT_NOARG,
+          aopt_set_literal(0),
+          aopt_set_string("histogram"),
+          "Build histogram of latencies. " },
+        { OPT_HISTOGRAM_LOWER_RANGE,
+          AOPT_ARG,
+          aopt_set_literal(0),
+          aopt_set_string("h_lower_range_us"),
+          "Lower range in microseconds of interest for latency histogram (default 0). " },
+        { OPT_HISTOGRAM_UPPER_RANGE,
+          AOPT_ARG,
+          aopt_set_literal(0),
+          aopt_set_string("h_upper_range_us"),
+          "Upper range in microseconds of interest for latency histogram (default 2 secs). " },
+        { OPT_HISTOGRAM_BIN_SIZE,
+          AOPT_ARG,
+          aopt_set_literal(0),
+          aopt_set_string("h_bin_size_us"),
+          "Bin size in microseconds for latency histogram (default 10). " },
         { 0, AOPT_NOARG, aopt_set_literal(0), aopt_set_string(NULL), NULL }
     };
 
@@ -946,6 +1063,83 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
                     aopt_get_long_name(self_opt_desc, OPT_CI_SIG_LVL));
                 rc = SOCKPERF_ERR_BAD_ARGUMENT;
             }
+        }
+
+        if (!rc && aopt_check(self_obj, OPT_HISTOGRAM)) {
+            s_user_params.b_histogram = true;
+            if (!rc && aopt_check(self_obj, OPT_HISTOGRAM_LOWER_RANGE)) {
+                const char *optarg = aopt_value(self_obj, OPT_HISTOGRAM_LOWER_RANGE);
+                if (optarg) {
+                    errno = 0;
+                    int value = strtol(optarg, NULL, 0);
+                    if (errno != 0 || value < 0) {
+                        log_msg("'--%s' Invalid lower range for histogram: %s",
+                            aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_LOWER_RANGE), optarg);
+                        rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                    } else {
+                        s_user_params.histogram_lower_range = value;
+                    }
+                } else {
+                    log_msg("'--%s' Invalid value",
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_LOWER_RANGE));
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                }
+            }
+
+            if (!rc && aopt_check(self_obj, OPT_HISTOGRAM_UPPER_RANGE)) {
+                const char *optarg = aopt_value(self_obj, OPT_HISTOGRAM_UPPER_RANGE);
+                if (optarg) {
+                    errno = 0;
+                    uint32_t value = strtol(optarg, NULL, 0);
+                    if (errno != 0 || value <= 0 || value < s_user_params.histogram_lower_range) {
+                        log_msg("'--%s' Invalid upper range for histogram: %s",
+                            aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_UPPER_RANGE), optarg);
+                        rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                    } else {
+                        s_user_params.histogram_upper_range = value;
+                    }
+                } else {
+                    log_msg("'--%s' Invalid value",
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_UPPER_RANGE));
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                }
+            }
+
+            if (!rc && aopt_check(self_obj, OPT_HISTOGRAM_BIN_SIZE)) {
+                const char *optarg = aopt_value(self_obj, OPT_HISTOGRAM_BIN_SIZE);
+                if (optarg) {
+                    errno = 0;
+                    uint32_t value = strtol(optarg, NULL, 0);
+                    uint32_t range = s_user_params.histogram_upper_range - s_user_params.histogram_lower_range;
+
+                    if (errno != 0 || value <= 0 || value > range) {
+                        printf("tiny value: %" PRIu32 "\n", value);
+                        log_msg("'--%s' Invalid bin size for histogram: %s.",
+                            aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_BIN_SIZE), optarg);
+                        rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                    } else {
+                        s_user_params.histogram_bin_size = value;
+                    }
+                } else {
+                    log_msg("'--%s' Invalid value",
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_BIN_SIZE));
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                }
+            }
+        }
+
+        if (!rc && aopt_check(self_obj, OPT_HISTOGRAM) == 0 &&
+            ( aopt_check(self_obj, OPT_HISTOGRAM_LOWER_RANGE) ||
+              aopt_check(self_obj, OPT_HISTOGRAM_UPPER_RANGE) ||
+              aopt_check(self_obj, OPT_HISTOGRAM_BIN_SIZE)
+            )
+           ) {
+            log_msg("Optional arguments '--%s' '--%s' '--%s' for histogram require flag '--%s'",
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_LOWER_RANGE),
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_UPPER_RANGE),
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_BIN_SIZE),
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM) );
+            rc = SOCKPERF_ERR_BAD_ARGUMENT;
         }
     }
 
@@ -1286,6 +1480,26 @@ static int proc_mode_playback(int id, int argc, const char **argv) {
           aopt_set_string("ci_sig_level"),
           "Normal confidence interval significance level for stat reported. Values are between 0 and 100 "
           "exclusive (default 99). " },
+        { OPT_HISTOGRAM,
+          AOPT_NOARG,
+          aopt_set_literal(0),
+          aopt_set_string("histogram"),
+          "Build histogram of latencies. " },
+        { OPT_HISTOGRAM_LOWER_RANGE,
+          AOPT_ARG,
+          aopt_set_literal(0),
+          aopt_set_string("h_lower_range_us"),
+          "Lower range in microseconds of interest for latency histogram (default 0). " },
+        { OPT_HISTOGRAM_UPPER_RANGE,
+          AOPT_ARG,
+          aopt_set_literal(0),
+          aopt_set_string("h_upper_range_us"),
+          "Upper range in microseconds of interest for latency histogram (default 2 secs). " },
+        { OPT_HISTOGRAM_BIN_SIZE,
+          AOPT_ARG,
+          aopt_set_literal(0),
+          aopt_set_string("h_bin_size_us"),
+          "Bin size in microseconds for latency histogram (default 10). " },
         { 0, AOPT_NOARG, aopt_set_literal(0), aopt_set_string(NULL), NULL }
     };
 
@@ -1375,6 +1589,83 @@ static int proc_mode_playback(int id, int argc, const char **argv) {
                     aopt_get_long_name(self_opt_desc, OPT_CI_SIG_LVL));
                 rc = SOCKPERF_ERR_BAD_ARGUMENT;
             }
+        }
+
+        if (!rc && aopt_check(self_obj, OPT_HISTOGRAM)) {
+            s_user_params.b_histogram = true;
+            if (!rc && aopt_check(self_obj, OPT_HISTOGRAM_LOWER_RANGE)) {
+                const char *optarg = aopt_value(self_obj, OPT_HISTOGRAM_LOWER_RANGE);
+                if (optarg) {
+                    errno = 0;
+                    int value = strtol(optarg, NULL, 0);
+                    if (errno != 0 || value < 0) {
+                        log_msg("'--%s' Invalid lower range for histogram: %s",
+                            aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_LOWER_RANGE), optarg);
+                        rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                    } else {
+                        s_user_params.histogram_lower_range = value;
+                    }
+                } else {
+                    log_msg("'--%s' Invalid value",
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_LOWER_RANGE));
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                }
+            }
+
+            if (!rc && aopt_check(self_obj, OPT_HISTOGRAM_UPPER_RANGE)) {
+                const char *optarg = aopt_value(self_obj, OPT_HISTOGRAM_UPPER_RANGE);
+                if (optarg) {
+                    errno = 0;
+                    uint32_t value = strtol(optarg, NULL, 0);
+                    if (errno != 0 || value <= 0 || value < s_user_params.histogram_lower_range) {
+                        log_msg("'--%s' Invalid upper range for histogram: %s",
+                            aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_UPPER_RANGE), optarg);
+                        rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                    } else {
+                        s_user_params.histogram_upper_range = value;
+                    }
+                } else {
+                    log_msg("'--%s' Invalid value",
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_UPPER_RANGE));
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                }
+            }
+
+            if (!rc && aopt_check(self_obj, OPT_HISTOGRAM_BIN_SIZE)) {
+                const char *optarg = aopt_value(self_obj, OPT_HISTOGRAM_BIN_SIZE);
+                if (optarg) {
+                    errno = 0;
+                    uint32_t value = strtol(optarg, NULL, 0);
+                    uint32_t range = s_user_params.histogram_upper_range - s_user_params.histogram_lower_range;
+
+                    if (errno != 0 || value <= 0 || value > range) {
+                        printf("tiny value: %" PRIu32 "\n", value);
+                        log_msg("'--%s' Invalid bin size for histogram: %s.",
+                            aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_BIN_SIZE), optarg);
+                        rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                    } else {
+                        s_user_params.histogram_bin_size = value;
+                    }
+                } else {
+                    log_msg("'--%s' Invalid value",
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_BIN_SIZE));
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                }
+            }
+        }
+
+        if (!rc && aopt_check(self_obj, OPT_HISTOGRAM) == 0 &&
+            ( aopt_check(self_obj, OPT_HISTOGRAM_LOWER_RANGE) ||
+              aopt_check(self_obj, OPT_HISTOGRAM_UPPER_RANGE) ||
+              aopt_check(self_obj, OPT_HISTOGRAM_BIN_SIZE)
+            )
+           ) {
+            log_msg("Optional arguments '--%s' '--%s' '--%s' for histogram require flag '--%s'",
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_LOWER_RANGE),
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_UPPER_RANGE),
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM_BIN_SIZE),
+                        aopt_get_long_name(self_opt_desc, OPT_HISTOGRAM) );
+            rc = SOCKPERF_ERR_BAD_ARGUMENT;
         }
     }
 
@@ -2313,6 +2604,10 @@ void set_defaults() {
     s_user_params.b_server_reply_via_uc = false;
     s_user_params.b_server_dont_reply = false;
     s_user_params.b_server_detect_gaps = false;
+
+    s_user_params.histogram_lower_range = 0;
+    s_user_params.histogram_upper_range = 2000000;
+    s_user_params.histogram_bin_size = 10;
 
     s_user_params.mps = MPS_DEFAULT;
     s_user_params.reply_every = REPLY_EVERY_DEFAULT;

--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -138,9 +138,9 @@ static const struct app_modes {
         aopt_set_string("ul"), "Run " MODULE_NAME " client for latency under load test." },
       { proc_mode_ping_pong,   "ping-pong",
         aopt_set_string("pp"), "Run " MODULE_NAME " client for latency test in ping pong mode." },
-      { proc_mode_playback, "playback", aopt_set_string("pb"),
-        "Run " MODULE_NAME " client for latency test using playback of predefined traffic, based "
-        "on timeline and message size." },
+      { proc_mode_playback, "playback",
+        aopt_set_string("pb"), "Run " MODULE_NAME " client for latency test using playback of predefined"
+                                                  " traffic, based on timeline and message size." },
       { proc_mode_throughput,  "throughput",
         aopt_set_string("tp"), "Run " MODULE_NAME " client for one way throughput test." },
       { proc_mode_server, "server", aopt_set_string("sr"), "Run " MODULE_NAME " as a server." },
@@ -653,6 +653,9 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
         { 't',                                                 AOPT_ARG,
           aopt_set_literal('t'),                               aopt_set_string("time"),
           "Run for <sec> seconds (default 1, max = 36000000)." },
+        { 'n',                                                 AOPT_ARG,
+          aopt_set_literal('n'),                               aopt_set_string("number-of-observations"),
+          "Run for observations (default 0, max = 100000000)." },
         { OPT_CLIENTPORT,
           AOPT_ARG,
           aopt_set_literal(0),
@@ -709,6 +712,7 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
 
     /* Set default values */
     s_user_params.mode = MODE_CLIENT;
+    s_user_params.measurement = TIME_BASED;
     s_user_params.b_client_ping_pong = true;
     s_user_params.mps = UINT32_MAX;
     s_user_params.reply_every = 1;
@@ -725,6 +729,24 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
 
     /* Set command line specific values */
     if (!rc && self_obj) {
+        if (!rc && aopt_check(self_obj, 'n')) {
+            const char *optarg = aopt_value(self_obj, 'n');
+            if (optarg) {
+                errno = 0;
+                int value = strtol(optarg, NULL, 0);
+                if (errno != 0 || value <= 0 || value > MAX_OBSERVATIONS) {
+                    log_msg("'-%c' Invalid observations: %s", 'n', optarg);
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                } else {
+                    s_user_params.measurement = OBSERVATION_BASED;
+                    s_user_params.observation_test_count = value;
+                }
+            } else {
+                log_msg("'-%c' Invalid value", 'n');
+                rc = SOCKPERF_ERR_BAD_ARGUMENT;
+            }
+        }
+
         if (!rc && aopt_check(self_obj, 't')) {
             const char *optarg = aopt_value(self_obj, 't');
             if (optarg) {
@@ -734,7 +756,13 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
                     log_msg("'-%c' Invalid duration: %s", 't', optarg);
                     rc = SOCKPERF_ERR_BAD_ARGUMENT;
                 } else {
-                    s_user_params.sec_test_duration = value;
+                    if (s_user_params.measurement == OBSERVATION_BASED) {
+                        log_msg("Can't be both observation and time based");
+                        rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                    } else {
+                        s_user_params.measurement = TIME_BASED;
+                        s_user_params.sec_test_duration = value;
+                    }
                 }
             } else {
                 log_msg("'-%c' Invalid value", 't');
@@ -878,10 +906,10 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
         printf("%s: %s\n", display_opt(id, temp_buf, sizeof(temp_buf)), sockperf_modes[id].note);
         printf("\n");
         printf("Usage: " MODULE_NAME " %s [options] [args]...\n", sockperf_modes[id].name);
-        printf(" " MODULE_NAME " %s -i ip  [-p port] [-m message_size] [-t time]\n",
+        printf(" " MODULE_NAME " %s -i ip  [-p port] [-m message_size] [-t time | -n number-of-observations]\n",
                sockperf_modes[id].name);
         printf(" " MODULE_NAME
-               " %s -f file [-F s/p/e] [-m message_size] [-r msg_size_range] [-t time]\n",
+               " %s -f file [-F s/p/e] [-m message_size] [-r msg_size_range] [-t time | -n number-of-observations]\n",
                sockperf_modes[id].name);
         printf("\n");
         printf("Options:\n");
@@ -2177,10 +2205,12 @@ void set_defaults() {
     s_user_params.tx_mc_if_addr.s_addr = htonl(INADDR_ANY);
     s_user_params.mc_source_ip_addr.s_addr = htonl(INADDR_ANY);
     s_user_params.sec_test_duration = DEFAULT_TEST_DURATION;
+    s_user_params.observation_test_count = DEFAULT_OBSERVATION_COUNT;
     s_user_params.client_bind_info.sin_family = AF_INET;
     s_user_params.client_bind_info.sin_addr.s_addr = INADDR_ANY;
     s_user_params.client_bind_info.sin_port = 0;
     s_user_params.mode = MODE_SERVER;
+    s_user_params.measurement = TIME_BASED;
     s_user_params.packetrate_stats_print_ratio = 0;
     s_user_params.packetrate_stats_print_details = false;
     s_user_params.burst_size = 1;
@@ -3240,6 +3270,8 @@ int bringup(const int *p_daemonize) {
                 TEST_FIRST_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC * 1000,
                 (int)(TEST_ANY_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC * 1000));
         }
+        s_user_params.warmup_obs = TEST_START_WARMUP_OBS;
+        s_user_params.cooldown_obs = TEST_END_COOLDOWN_OBS;
 
         uint64_t _maxTestDuration = 1 + s_user_params.sec_test_duration +
                                     (s_user_params.warmup_msec + s_user_params.cooldown_msec) /
@@ -3247,6 +3279,11 @@ int bringup(const int *p_daemonize) {
         uint64_t _maxSequenceNo = _maxTestDuration * s_user_params.mps +
                                   10 * s_user_params.reply_every; // + 10 replies for safety
         _maxSequenceNo += s_user_params.burst_size; // needed for the case burst_size > mps
+
+        if(s_user_params.measurement == OBSERVATION_BASED) {
+            // override to reach max count during observation based
+            _maxSequenceNo = TEST_START_WARMUP_OBS + MAX_OBSERVATIONS + TEST_END_COOLDOWN_OBS;
+        }
 
         if (s_user_params.pPlaybackVector) {
             _maxSequenceNo = s_user_params.pPlaybackVector->size();
@@ -3350,10 +3387,12 @@ int main(int argc, char *argv[]) {
         log_dbg(
             "+INFO:\n\t\
 mode = %d \n\t\
+measurement = %d \n\t\
 with_sock_accl = %d \n\t\
 msg_size = %d \n\t\
 msg_size_range = %d \n\t\
 sec_test_duration = %d \n\t\
+observation_test_count = %d \n\t\
 data_integrity = %d \n\t\
 packetrate_stats_print_ratio = %d \n\t\
 burst_size = %d \n\t\
@@ -3389,14 +3428,14 @@ daemonize = %d \n\t\
 feedfile_name = %s \n\t\
 tos = %d \n\t\
 packet pace limit = %d",
-            s_user_params.mode, s_user_params.withsock_accl, s_user_params.msg_size,
-            s_user_params.msg_size_range, s_user_params.sec_test_duration,
-            s_user_params.data_integrity, s_user_params.packetrate_stats_print_ratio,
-            s_user_params.burst_size, s_user_params.packetrate_stats_print_details,
-            s_user_params.fd_handler_type, s_user_params.mthread_server,
-            s_user_params.sock_buff_size, s_user_params.threads_num, s_user_params.threads_affinity,
-            s_user_params.is_blocked, s_user_params.is_nonblocked_send, s_user_params.do_warmup,
-            s_user_params.pre_warmup_wait, s_user_params.is_vmarxfiltercb,
+            s_user_params.mode, s_user_params.measurement, s_user_params.withsock_accl,
+            s_user_params.msg_size, s_user_params.msg_size_range, s_user_params.sec_test_duration,
+            s_user_params.observation_test_count, s_user_params.data_integrity,
+            s_user_params.packetrate_stats_print_ratio, s_user_params.burst_size,
+            s_user_params.packetrate_stats_print_details, s_user_params.fd_handler_type,
+            s_user_params.mthread_server, s_user_params.sock_buff_size, s_user_params.threads_num,
+            s_user_params.threads_affinity, s_user_params.is_blocked, s_user_params.is_nonblocked_send,
+            s_user_params.do_warmup, s_user_params.pre_warmup_wait, s_user_params.is_vmarxfiltercb,
             s_user_params.is_vmazcopyread, s_user_params.mc_loop_disable, s_user_params.mc_ttl,
             s_user_params.uc_reuseaddr, s_user_params.tcp_nodelay,
             s_user_params.client_work_with_srv_num, s_user_params.b_server_reply_via_uc,

--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -139,8 +139,8 @@ static const struct app_modes {
       { proc_mode_ping_pong,   "ping-pong",
         aopt_set_string("pp"), "Run " MODULE_NAME " client for latency test in ping pong mode." },
       { proc_mode_playback, "playback",
-        aopt_set_string("pb"), "Run " MODULE_NAME " client for latency test using playback of predefined"
-                                                  " traffic, based on timeline and message size." },
+        aopt_set_string("pb"), "Run " MODULE_NAME " client for latency test using playback of predefined "
+                               "traffic, based on timeline and message size." },
       { proc_mode_throughput,  "throughput",
         aopt_set_string("tp"), "Run " MODULE_NAME " client for one way throughput test." },
       { proc_mode_server, "server", aopt_set_string("sr"), "Run " MODULE_NAME " as a server." },
@@ -400,6 +400,12 @@ static int proc_mode_under_load(int id, int argc, const char **argv) {
           aopt_set_literal('r'),
           aopt_set_string("range"),
           "comes with -m <size>, randomly change the messages size in range: <size> +- <N>." },
+        { OPT_CI_SIG_LVL,
+          AOPT_OPTARG,
+          aopt_set_literal(0),
+          aopt_set_string("ci_sig_level"),
+          "Normal confidence interval significance level for stat reported. Values are between 0 and 100 "
+          "exclusive (default 99). " },
         { 0, AOPT_NOARG, aopt_set_literal(0), aopt_set_string(NULL), NULL }
     };
 
@@ -595,6 +601,25 @@ static int proc_mode_under_load(int id, int argc, const char **argv) {
                 rc = SOCKPERF_ERR_BAD_ARGUMENT;
             }
         }
+
+        if (!rc && aopt_check(self_obj, OPT_CI_SIG_LVL)) {
+            const char *optarg = aopt_value(self_obj, OPT_CI_SIG_LVL);
+            if (optarg) {
+                errno = 0;
+                int value = strtol(optarg, NULL, 0);
+                if (errno != 0 || value <= 0 || value >= 100) {
+                    log_msg("'--%s' Invalid Significance level: %s",
+                        aopt_get_long_name(self_opt_desc, OPT_CI_SIG_LVL), optarg);
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                } else {
+                    s_user_params.ci_significance_level = value;
+                }
+            } else {
+                log_msg("'--%s' Invalid value",
+                    aopt_get_long_name(self_opt_desc, OPT_CI_SIG_LVL));
+                rc = SOCKPERF_ERR_BAD_ARGUMENT;
+            }
+        }
     }
 
     if (rc) {
@@ -684,6 +709,12 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
           "comes with -m <size>, randomly change the messages size in range: <size> +- <N>." },
         { OPT_DATA_INTEGRITY,                AOPT_NOARG,                    aopt_set_literal(0),
           aopt_set_string("data-integrity"), "Perform data integrity test." },
+        { OPT_CI_SIG_LVL,
+          AOPT_OPTARG,
+          aopt_set_literal(0),
+          aopt_set_string("ci_sig_level"),
+          "Normal confidence interval significance level for stat reported. Values are between 0 and 100 "
+          "exclusive (default 99). " },
         { 0, AOPT_NOARG, aopt_set_literal(0), aopt_set_string(NULL), NULL }
     };
 
@@ -894,6 +925,25 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
                 s_user_params.data_integrity = true;
             } else {
                 log_msg("--data-integrity conflicts with -b option");
+                rc = SOCKPERF_ERR_BAD_ARGUMENT;
+            }
+        }
+
+        if (!rc && aopt_check(self_obj, OPT_CI_SIG_LVL)) {
+            const char *optarg = aopt_value(self_obj, OPT_CI_SIG_LVL);
+            if (optarg) {
+                errno = 0;
+                int value = strtol(optarg, NULL, 0);
+                if (errno != 0 || value <= 0 || value >= 100) {
+                    log_msg("'--%s' Invalid Significance level: %s",
+                        aopt_get_long_name(self_opt_desc, OPT_CI_SIG_LVL), optarg);
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                } else {
+                    s_user_params.ci_significance_level = value;
+                }
+            } else {
+                log_msg("'--%s' Invalid value",
+                    aopt_get_long_name(self_opt_desc, OPT_CI_SIG_LVL));
                 rc = SOCKPERF_ERR_BAD_ARGUMENT;
             }
         }
@@ -1230,6 +1280,12 @@ static int proc_mode_playback(int id, int argc, const char **argv) {
         { OPT_PLAYBACK_DATA,                                         AOPT_ARG,
           aopt_set_literal(0),                                       aopt_set_string("data-file"),
           "Pre-prepared CSV file with timestamps and message sizes." },
+        { OPT_CI_SIG_LVL,
+          AOPT_OPTARG,
+          aopt_set_literal(0),
+          aopt_set_string("ci_sig_level"),
+          "Normal confidence interval significance level for stat reported. Values are between 0 and 100 "
+          "exclusive (default 99). " },
         { 0, AOPT_NOARG, aopt_set_literal(0), aopt_set_string(NULL), NULL }
     };
 
@@ -1298,6 +1354,25 @@ static int proc_mode_playback(int id, int argc, const char **argv) {
                 }
             } else {
                 log_msg("'-%d' Invalid value", OPT_REPLY_EVERY);
+                rc = SOCKPERF_ERR_BAD_ARGUMENT;
+            }
+        }
+
+        if (!rc && aopt_check(self_obj, OPT_CI_SIG_LVL)) {
+            const char *optarg = aopt_value(self_obj, OPT_CI_SIG_LVL);
+            if (optarg) {
+                errno = 0;
+                int value = strtol(optarg, NULL, 0);
+                if (errno != 0 || value <= 0 || value >= 100) {
+                    log_msg("'--%s' Invalid Significance level: %s",
+                        aopt_get_long_name(self_opt_desc, OPT_CI_SIG_LVL), optarg);
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                } else {
+                    s_user_params.ci_significance_level = value;
+                }
+            } else {
+                log_msg("'--%s' Invalid value",
+                    aopt_get_long_name(self_opt_desc, OPT_CI_SIG_LVL));
                 rc = SOCKPERF_ERR_BAD_ARGUMENT;
             }
         }
@@ -2209,6 +2284,7 @@ void set_defaults() {
     s_user_params.client_bind_info.sin_family = AF_INET;
     s_user_params.client_bind_info.sin_addr.s_addr = INADDR_ANY;
     s_user_params.client_bind_info.sin_port = 0;
+    s_user_params.ci_significance_level = DEFAULT_CI_SIG_LEVEL;
     s_user_params.mode = MODE_SERVER;
     s_user_params.measurement = TIME_BASED;
     s_user_params.packetrate_stats_print_ratio = 0;

--- a/src/ticks.cpp
+++ b/src/ticks.cpp
@@ -212,7 +212,7 @@ public:
     double scaleToConsistentEstimatorForStdDev = 1.48260221851;
 
     for (size_t i = 0; i < size; i++) {
-        if(pArr[i] < median) {
+        if (pArr[i] < median) {
             deviationsFromMedian[i] = median - pArr[i];
         } else {
             deviationsFromMedian[i] = pArr[i] - median;

--- a/src/ticks.h
+++ b/src/ticks.h
@@ -345,6 +345,18 @@ public:
     //------------------------------------------------------------------------------
     static TicksDuration stdDev(TicksDuration *pArr, size_t size);
 
+    //------------------------------------------------------------------------------
+    static TicksDuration mad(TicksDuration *pArr, size_t size);
+
+    //------------------------------------------------------------------------------
+    static TicksDuration medianad(TicksDuration *pArr, size_t size);
+
+    //------------------------------------------------------------------------------
+    static TicksDuration siqr(TicksDuration *pArr, size_t size);
+
+    //------------------------------------------------------------------------------
+    static TicksDuration median(TicksDuration *pArr, size_t size, bool sortList);
+
 private:
     inline explicit TicksDuration(ticks_t _ticks, bool) : TicksBase(_ticks) {}
     explicit TicksDuration(int64_t _nsec, int); // provide non inline function for reducing code


### PR DESCRIPTION
**Motive:**

Currently, sockperf runs until a timer completes which produces an undetermined number of data rows. Observational-based measurements produce an exact number which eases sockperf run comparisons (such as with stats) and avoids potential overflow during high data collection. Compute more stats directly from measurements to take advantage of sockperf's `ticks` (nanosecond precision). Produce microsecond resolution sparse fixed bin histogram from measurements to provide a visual display of data.

**Changes:**
Obervational-based
- Parser accepts `-n` for number of observations. This measurement type is only for ping-pong mode
- Observational warmup/cooldown when in observational mode instead of adding warmup/cooldown time to timer
- Tracking valid observations in `doSendThenReceiveLoop`, where `client_send_then_receive` is blocking
- Time cap based on warm up sample to limit waiting on observations

Stats
- Add mean absolute deviation, median absolute deviation, semi-interquartile range, coefficient of variance, standard error, and confidence interval 
- Confidence interval significance level configurable via arg flag `--ci_sig_level` (includes decimals)
- Inverse CDF (or ppf) function to compute confidence interval  for any significance level (0-100 exclusive)
- Getter for long name of options for logging purposes
- Sort latency list once where other stats can reuse

Histogram
- Build histogram and display histogram on terminal for a quick view (frequency rounded up)
- Store raw histogram data to log file if present
- Histogram flags for histogram bin size, lower range, and upper range of interest configurable via cmd respectively `-histogram {bin size}:{lower range}:{upper range}`
- Left and right outlier bins to capture all data outside given range

**Manual Self-Testing:**
Ran server and client locally and manually verified logX.txt had the expected observational data count.
`./sockperf sr -i 127.0.0.1`
`./sockperf pp -i 127.0.0.1 -n 1000 -m 64 --full-log log.txt` -> 1000
`./sockperf pp -i 127.0.0.1 -n 1         -m 64 --full-log logA.txt` -> 1\
`./sockperf pp -i 127.0.0.1 -n -1        -m 64 --full-log logC.txt` -> failed to help page as expected
`./sockperf pp -i 127.0.0.1 -n 100000001 -m 64 --full-log logD.txt` -> failed to help page as expected
`./sockperf pp -i 127.0.0.1 -n 100000000 -m 64 --full-log logE.txt` -> 100000000 (max obs imposed)


`./sockperf pp -i 127.0.0.1 -n 1000 -m 64 --ci_sig_level 80 --full-log log.txt --full-rtt`
All stat changes are reported in magenta line `sockperf: ====> avg-rtt...`.
![image](https://user-images.githubusercontent.com/20761371/108804256-c3639a80-756a-11eb-963c-53ea3cbccb45.png)


`./sockperf pp -i 127.0.0.1 -n 1000000 -m 64 --histogram 1:25:60 --full-log log.txt --full-rtt`

All histogram changes are after `sockperf: [Histogram]...`
![image](https://user-images.githubusercontent.com/20761371/133393025-78f18cfd-767a-448b-a949-300a0dd6cf49.png)

Raw histogram content at the end of log file:
```
------------------------------
histogram was built using the following parameters: --h_bin_size_us=1 --h_lower_range_us=25 --h_upper_range_us=60
------------------------------
bin (usec)            frequency
36                         1
37                         1
38                         343
39                         2555
40                         1715
41                         1712
42                         2635
43                         25658
44                         41436
45                         181808
46                         84039
47                         31985
48                         27579
49                         127625
50                         180704
51                         61690
52                         23414
53                         14486
54                         11610
55                         10912
56                         9841
57                         7917
58                         6856
59                         5880
60-3938                    137598
------------------------------
```