### PR TITLE
issue: 2679482 Sockperf server reports an error with 6000 connections and Epoll IOMUX when TLS is enabled

### DIFF
--- a/src/tls.cpp
+++ b/src/tls.cpp
@@ -175,6 +175,13 @@ const char *tls_chipher(const char *chipher) {
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 
+// This define is only applicable for OpenSSL 3, in OpenSSL 1.1.1 the behaviour
+// of unclean shutdown is not strict and does not generate an error.
+// So this flag was introduced for OpenSSL 3 as to imitate the old behaviour.
+#ifndef SSL_OP_IGNORE_UNEXPECTED_EOF
+#define SSL_OP_IGNORE_UNEXPECTED_EOF 0
+#endif
+
 static SSL_CTX *ssl_ctx = NULL;
 
 int tls_init(void) {
@@ -195,7 +202,8 @@ int tls_init(void) {
         }
 
         if (SSL_CTX_set_options(ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1 |
-                                         SSL_OP_NO_TLSv1_1 | SSL_OP_NO_TLSv1_3) <= 0) {
+                                         SSL_OP_NO_TLSv1_1 | SSL_OP_NO_TLSv1_3 |
+                                         SSL_OP_IGNORE_UNEXPECTED_EOF) <= 0) {
             SSL_CTX_free(ctx);
             log_err("Unable to set protocol: %s", "TLSv1.2");
             rc = SOCKPERF_ERR_FATAL;


### PR DESCRIPTION
Sockperf server reports an error with 6000 connections and Epoll IOMUX when TLS is enabled.
Make openssl not to issue a fatal closure when unexpected EOF (like RST) is received using SSL_OP_IGNORE_UNEXPECTED_EOF flag. Otherwise openssl sends close_notify on a reset/closed socket which results in SIGPIPE and other different issues even if SIGPIPE is ignored.
If SIGPIPE is ignored, two other issues rise:
1. EBADMSG is received from SSL_read (in case of kTLS).
2. SSL_ERROR_SSL is returned from SSL_read (non kTLS).