### PR TITLE
Fix null pointer access

### DIFF
--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -1905,7 +1905,7 @@ static int parse_common_opt(const AOPT_OBJECT *common_obj) {
                     }
                 }
             } else {
-                log_msg("'-%d' Invalid address: %s", OPT_MC_SOURCE_IP, optarg);
+                log_msg("'-%d' Expecting a value", OPT_MC_SOURCE_IP);
                 rc = SOCKPERF_ERR_BAD_ARGUMENT;
             }
         }


### PR DESCRIPTION
In case the value of --mc-source-filter (which should be the IP address) is not found the log message is trying to print the IP address which in this case is definite NULL.