### PR TITLE
issue: 2890836 support IPv6

### DIFF
--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -349,4 +349,6 @@ pipeline_stop:
 
 failFast: false
 
+timeout_minutes: 150
+
 taskName: '${flags}/${name}/${axis_index}'

--- a/Makefile.am
+++ b/Makefile.am
@@ -28,6 +28,8 @@ sockperf_SOURCES = \
 	src/input_handlers.h \
 	src/iohandlers.cpp \
 	src/iohandlers.h \
+	src/ip_address.cpp \
+	src/ip_address.h \
 	src/message.cpp \
 	src/message.h \
 	src/message_parser.h \
@@ -37,6 +39,7 @@ sockperf_SOURCES = \
 	src/packet.h \
 	src/playback.cpp \
 	src/playback.h \
+	src/port_descriptor.h \
 	src/server.cpp \
 	src/server.h \
 	src/sockperf.cpp \

--- a/contrib/jenkins_tests/globals.sh
+++ b/contrib/jenkins_tests/globals.sh
@@ -197,7 +197,7 @@ function do_check_result()
 }
 
 # Detect interface ip
-# $1 - [ib|eth] to select link type or empty to select the first found
+# $1 - [ib|eth|eth6] to select link type or empty to select the first found
 # $2 - [empty|mlx4|mlx5]
 # $3 - ip address not to get
 #
@@ -251,6 +251,8 @@ function do_get_ip()
             fi
         elif [ -n "$1" -a "$1" == "eth" -a -n "$(ip link show $ip | grep 'link/eth')" ]; then
             found_ip=$(ip -4 address show $ip | grep 'inet' | sed 's/.*inet \([0-9\.]\+\).*/\1/')
+        elif [ -n "$1" -a "$1" == "eth6" -a -n "$(ip link show $ip | grep 'link/eth')" ]; then
+            found_ip=$(ip -6 address show $ip | grep 'scope global' | sed 's/.*inet6 \([0-9a-f:\.]\+\).*/\1/')
         elif [ -z "$1" ]; then
             found_ip=$(ip -4 address show $ip | grep 'inet' | sed 's/.*inet \([0-9\.]\+\).*/\1/')
         fi

--- a/contrib/jenkins_tests/test.sh
+++ b/contrib/jenkins_tests/test.sh
@@ -26,8 +26,18 @@ if [ $(command -v $test_app >/dev/null 2>&1 || echo $?) ]; then
     exit 1
 fi
 
-if [ ! -z $(do_get_ip 'eth') ]; then
-    test_ip_list="${test_ip_list} eth:$(do_get_ip 'eth')"
+ip=$(do_get_ip 'eth')
+if [ -n "$ip" ]; then
+    test_ip_list="${test_ip_list} eth:$ip"
+fi
+ip=$(do_get_ip 'eth6')
+if [ -n "$ip" ]; then
+    test_ip_list="${test_ip_list} eth6:$ip"
+fi
+
+if [ -z "$test_ip_list" ]; then
+    echo "no IP addresses detected"
+    rc=1
 fi
 
 test_list="tcp-pp tcp-tp tcp-ul udp-pp udp-tp udp-ul"
@@ -40,9 +50,9 @@ for test_link in $test_ip_list; do
 		test_name=${test_in}-${test}
 		test_tap=${WORKSPACE}/${prefix}/test-${test_name}.tap
 
-		$timeout_exe ${WORKSPACE}/tests/verifier/verifier.pl -a ${test_app} \
-			-t ${test} -s ${test_ip} -l ${test_dir}/${test_name}.log \
-			--progress=0
+        $timeout_exe ${WORKSPACE}/tests/verifier/verifier.pl -a ${test_app} \
+            -t ${test} -s ${test_ip} -l ${test_dir}/${test_name}.log \
+            --progress=0
 
 		# exclude multicast tests from final result
 		# because they are not valid when server/client on the same node

--- a/doc/main.dox
+++ b/doc/main.dox
@@ -101,10 +101,13 @@ sockperf: [tid 4805] using epoll() to block on socket(s)
 
    Every line in feed file should have following format as
    [U|T]:address:port
+   or
+   [U|T]:address:port:mc_src_addr
    where
    - [U|T] - UDP or TCP protocol;
-   - address - Internet Protocol (IP) address;
+   - address - Internet Protocol (IP) address or host name (IPv6 addresses must be enclosed in square brackets);
    - port - Port number;
+   - mc_src_addr - Optional multicast source IP address or host name.
 
 
 @subsection _option 3.1 Available options

--- a/src/input_handlers.h
+++ b/src/input_handlers.h
@@ -46,12 +46,12 @@ public:
     /** Receive pending data from a socket
      * @param [in] socket descriptor
      * @param [out] recvfrom_addr address to save peer address into
+     * @param [inout] in - storage size, out - actual address size
      * @return status code
      */
-    inline int receive_pending_data(int fd, struct sockaddr_in *recvfrom_addr)
+    inline int receive_pending_data(int fd, struct sockaddr *recvfrom_addr, socklen_t &size)
     {
         int ret = 0;
-        socklen_t size = sizeof(struct sockaddr_in);
         int flags = 0;
         uint8_t *buf = m_recv_data.cur_addr + m_recv_data.cur_offset;
 
@@ -84,8 +84,9 @@ public:
 #endif /* LOG_TRACE_MSG_IN */
 
 #if defined(LOG_TRACE_RECV) && (LOG_TRACE_RECV == TRUE)
-        LOG_TRACE("raw", "%s IP: %s:%d [fd=%d ret=%d] %s", __FUNCTION__,
-                  inet_ntoa(recvfrom_addr->sin_addr), ntohs(recvfrom_addr->sin_port), fd, ret,
+        std::string hostport = sockaddr_to_hostport(recvfrom_addr);
+        LOG_TRACE("raw", "%s IP: %s [fd=%d ret=%d] %s", __FUNCTION__,
+                  hostport.c_str(), fd, ret,
                   strerror(errno));
 #endif /* LOG_TRACE_RECV */
 
@@ -133,11 +134,14 @@ public:
     /** Receive pending data from a socket
      * @param [in] socket descriptor
      * @param [out] recvfrom_addr address to save peer address into
+     * @param [inout] in - storage size, out - actual address size
      * @return status code
      */
-    inline int receive_pending_data(int fd, struct sockaddr_in *recvfrom_addr)
+    inline int receive_pending_data(int fd, struct sockaddr *recvfrom_addr, socklen_t &size)
     {
-        *recvfrom_addr = g_vma_comps->src;
+        //TODO: update after IPv6 will be supported in libvma
+        size = sizeof(sockaddr_in);
+        std::memcpy(recvfrom_addr, &g_vma_comps->src, size);
         m_vma_buff = g_vma_buff;
         if (likely(m_vma_buff)) {
             return m_vma_buff->len;
@@ -182,12 +186,12 @@ public:
     /** Receive pending data from a socket
      * @param [in] socket descriptor
      * @param [out] recvfrom_addr address to save peer address into
+     * @param [inout] in - storage size, out - actual address size
      * @return status code
      */
-    inline int receive_pending_data(int fd, struct sockaddr_in *recvfrom_addr)
+    inline int receive_pending_data(int fd, struct sockaddr *recvfrom_addr, socklen_t &size)
     {
         int ret = 0;
-        socklen_t size = sizeof(struct sockaddr_in);
         int flags = 0;
 
         m_fd = fd;

--- a/src/iohandlers.h
+++ b/src/iohandlers.h
@@ -28,6 +28,8 @@
 
 #ifndef IOHANDLERS_H_
 #define IOHANDLERS_H_
+
+#include "defs.h"
 #include "common.h"
 
 //==============================================================================

--- a/src/ip_address.cpp
+++ b/src/ip_address.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2021-2022 Mellanox Technologies Ltd.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of the Mellanox Technologies Ltd nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ */
+
+#include "ip_address.h"
+
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <string.h>
+
+bool IPAddress::resolve(const char *str, IPAddress &out, std::string &err)
+{
+    struct addrinfo hints;
+
+    memset(&hints, 0, sizeof(hints));
+    // allow IPv4 or IPv6
+    hints.ai_family = AF_UNSPEC;
+    // return addresses only from configured address families
+    hints.ai_flags = AI_ADDRCONFIG;
+    // any protocol
+    hints.ai_protocol = 0;
+    // any socket type
+    hints.ai_socktype = 0;
+
+    struct addrinfo *result;
+    int res = getaddrinfo(str, NULL, &hints, &result);
+    if (res == 0) {
+        out.m_family = AF_UNSPEC;
+        for (const addrinfo *rp = result; rp != NULL; rp = rp->ai_next) {
+            if (rp->ai_family == AF_INET6) {
+                out.m_family = rp->ai_family;
+                out.m_addr6 = reinterpret_cast<const sockaddr_in6 *>(rp->ai_addr)->sin6_addr;
+            }
+        }
+        if (out.m_family == AF_UNSPEC) {
+            for (addrinfo *rp = result; rp != NULL; rp = rp->ai_next) {
+                out.m_family = rp->ai_family;
+                out.m_addr4 = reinterpret_cast<const sockaddr_in *>(rp->ai_addr)->sin_addr;
+            }
+        }
+    } else {
+        err = gai_strerror(res);
+    }
+    freeaddrinfo(result);
+
+    return res == 0;
+}
+
+IPAddress IPAddress::zero()
+{
+    IPAddress res;
+    memset(&res.m_addr6, 0, sizeof(res.m_addr6));
+    return res;
+}
+
+bool IPAddress::is_specified() const
+{
+    switch (m_family) {
+    case AF_INET:
+        return m_addr4.s_addr != INADDR_ANY;
+    case AF_INET6:
+        return !IN6_IS_ADDR_UNSPECIFIED(&m_addr6);
+    }
+    return false;
+}
+
+std::string IPAddress::toString() const
+{
+    if (m_family == AF_UNSPEC) {
+        return "(unspec)";
+    }
+    char hbuf[INET6_ADDRSTRLEN];
+    const char *res = inet_ntop(m_family, &m_addr4, hbuf, INET6_ADDRSTRLEN);
+    if (res) {
+        return res;
+    } else {
+        return "(unknown)";
+    }
+}

--- a/src/ip_address.h
+++ b/src/ip_address.h
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2021-2022 Mellanox Technologies Ltd.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of the Mellanox Technologies Ltd nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ */
+
+#ifndef IP_ADDRESS_H_
+#define IP_ADDRESS_H_
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+
+#include <functional>
+#include <string>
+
+#ifndef __FreeBSD__
+#include <tr1/unordered_map>
+#else
+#include <unordered_map>
+#endif
+
+class IPAddress {
+private:
+    sa_family_t m_family;
+    union {
+        in_addr m_addr4;
+        in6_addr m_addr6;
+    };
+
+public:
+    static bool resolve(const char *str, IPAddress &out, std::string &err);
+    static IPAddress zero();
+
+    IPAddress() : m_family(AF_UNSPEC)
+    {
+    }
+
+    IPAddress(const IPAddress &rhs) : m_family(rhs.m_family), m_addr6(rhs.m_addr6)
+    {
+    }
+
+    IPAddress(const sockaddr *sa, socklen_t len)
+    {
+        if (len < sizeof(m_family)) {
+            m_family = AF_UNSPEC;
+            return;
+        }
+        m_family = sa->sa_family;
+        switch (m_family) {
+        case AF_INET:
+            if (len >= sizeof(sockaddr_in)) {
+                m_addr4 = reinterpret_cast<const sockaddr_in *>(sa)->sin_addr;
+            } else {
+                m_family = AF_UNSPEC;
+            }
+            break;
+        case AF_INET6:
+            if (len >= sizeof(sockaddr_in6)) {
+                m_addr6 = reinterpret_cast<const sockaddr_in6 *>(sa)->sin6_addr;
+            } else {
+                m_family = AF_UNSPEC;
+            }
+            break;
+        }
+    }
+
+    inline sa_family_t family() const
+    {
+        return m_family;
+    }
+
+    inline const in_addr &addr4() const
+    {
+        return m_addr4;
+    }
+
+    inline const in6_addr &addr6() const
+    {
+        return m_addr6;
+    }
+
+    bool is_specified() const;
+
+    std::string toString() const;
+
+    inline friend bool operator==(const IPAddress &key1, const IPAddress &key2)
+    {
+        if (key1.m_family == key2.m_family) {
+            switch (key1.m_family) {
+            case AF_UNSPEC:
+                return true;
+            case AF_INET:
+                return key1.m_addr4.s_addr == key2.m_addr4.s_addr;
+            case AF_INET6:
+                return IN6_ARE_ADDR_EQUAL(&key1.m_addr6, &key2.m_addr6);
+            }
+        }
+        return false;
+    }
+};
+
+// The only types that TR1 has built-in hash/equal_to functions for, are scalar types,
+// std:: string, and std::wstring. For any other type, we need to write a
+// hash/equal_to functions, by ourself.
+namespace std {
+#if !defined(WIN32) && !defined(__FreeBSD__)
+namespace tr1 {
+#endif
+template <> struct hash<IPAddress> : public std::unary_function<IPAddress, int> {
+    int operator()(IPAddress const &key) const
+    {
+        switch (key.family()) {
+        case AF_INET:
+            return key.addr4().s_addr & 0xFF;
+        case AF_INET6: {
+            const uint32_t *addr = reinterpret_cast<const uint32_t *>(&key.addr6());
+            return addr[0] ^ addr[1] ^ addr[2] ^ addr[3];
+        }
+        default:
+            return 0;
+        }
+    }
+};
+#if !defined(WIN32) && !defined(__FreeBSD__)
+} // closes namespace tr1
+#endif
+
+template <>
+struct equal_to<IPAddress> : public std::binary_function<IPAddress, IPAddress,
+                                                              bool> {
+    bool operator()(IPAddress const &key1, IPAddress const &key2) const {
+        return key1 == key2;
+    }
+};
+
+} // namespace std
+
+#endif // IP_ADDRESS_H_

--- a/src/os_abstract.h
+++ b/src/os_abstract.h
@@ -74,7 +74,6 @@
 #define __func__ __FUNCTION__
 
 // Socket api
-#define inet_aton(x, y) inet_pton(AF_INET, x, y)
 #define getsockopt(a, b, c, d, e) getsockopt(a, b, c, (char *)d, e)
 #define setsockopt(a, b, c, d, e) setsockopt(a, b, c, (char *)d, e)
 #define recvfrom(a, b, c, d, e, f) recvfrom(a, (char *)b, c, d, e, f)

--- a/src/port_descriptor.h
+++ b/src/port_descriptor.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2021-2022 Mellanox Technologies Ltd.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of the Mellanox Technologies Ltd nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ */
+
+#ifndef PORT_DESCRIPTOR_H_
+#define PORT_DESCRIPTOR_H_
+
+#include <stdint.h>
+
+#ifdef WIN32
+
+typedef uint16_t in_port_t;
+
+#else
+
+#include <netinet/in.h>  /* internet address manipulation */
+
+#endif // WIN32
+
+typedef struct port_descriptor {
+    int sock_type; /**< SOCK_STREAM (tcp), SOCK_DGRAM (udp), SOCK_RAW (ip) */
+    sa_family_t family; // AF_INET, AF_INET6
+    in_port_t port;
+} port_type;
+
+// The only types that TR1 has built-in hash/equal_to functions for, are scalar types,
+// std:: string, and std::wstring. For any other type, we need to write a
+// hash/equal_to functions, by ourself.
+namespace std {
+#if !defined(WIN32) && !defined(__FreeBSD__)
+namespace tr1 {
+#endif
+
+template <>
+struct hash<struct port_descriptor> : public std::unary_function<struct port_descriptor, int> {
+    int operator()(struct port_descriptor const &key) const {
+        return key.sock_type ^ key.port ^ key.family;
+    }
+};
+#if !defined(WIN32) && !defined(__FreeBSD__)
+} // closes namespace tr1
+#endif
+
+template <>
+struct equal_to<struct port_descriptor> : public std::binary_function<struct port_descriptor,
+                                                                    struct port_descriptor, bool> {
+    bool operator()(struct port_descriptor const &key1, struct port_descriptor const &key2) const {
+        return key1.sock_type == key2.sock_type
+            && key1.family == key2.family
+            && key1.port == key2.port;
+    }
+};
+
+} // namespace std
+
+#endif // PORT_DESCRIPTOR_H_

--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -3455,7 +3455,7 @@ int bringup(const int *p_daemonize) {
                 "Warm-up set in relation to number of active connections. Warm up time: %" PRIu32
                 " usec; first connection's first packet TTL: %d usec; following connections' first "
                 "packet TTL: %d usec\n",
-                g_pApp->m_const_params.warmup_msec,
+                s_user_params.warmup_msec,
                 TEST_FIRST_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC * 1000,
                 (int)(TEST_ANY_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC * 1000));
         }

--- a/tests/verifier/lib/TE/Funclet.pm
+++ b/tests/verifier/lib/TE/Funclet.pm
@@ -262,7 +262,12 @@ sub execute
         # Execute script
         # which means $cmd will 'pipe' its output to SHELL. That means SHELL can be used 
         # to read the output of the command (specifically the stuff the command sends to STDOUT).
-        $cmd = "ssh $$TARGET " . $cmd; 
+        if ($$TARGET =~ m/:/) {
+            # tell ssh to use IPv6 address
+            $cmd = "ssh -6 $$TARGET " . $cmd;
+        } else {
+            $cmd = "ssh $$TARGET " . $cmd;
+        }
         eval { open SHELL, "$cmd 2>&1 |"  or die $! };
         my $eval_err = $@;
         if ( !get_error() && $eval_err )


### PR DESCRIPTION
Summary of changes:
* Added support for IPv4/IPv6/hostname in all places previously supporting only IPv4. In a feedfile IPv6 addresses must be enclosed into square brackets. Resolver prefers IPv6 addresses because :: can listen for both IPv4 and IPv6 clients.
* I use own structure `sockaddr_store_t` to store socket addresses because default sockaddr_storage is 128 bytes long and it is too big for us.
* Improved regexp usage: one regexp per loop instead of one regexp per iteration.

Limitations:
* IPv6 is not supported in VMA SocketXtreme because of API limitations.
* Windows support is broken. Need C++11 (std::regexp) or our sophisticated parser to parse feedfile. Will be fixed in RM#2904933.
* IPv6 multicast support is incomplete. There are no direct equivalents of IPv4 group membership sockopts, need to study more about it. Will be added in RM#2904936.