### PR TITLE
issue: 3002911 Fix error when compiling OpenSSL 3.0.0

### DIFF
--- a/src/tls.cpp
+++ b/src/tls.cpp
@@ -121,7 +121,7 @@ int tls_init(void) {
         goto error_free_ctx;
     }
 
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+#if OPENSSL_VERSION_NUMBER > 0x30000000L
     SSL_CTX_set_options(ctx, SSL_OP_ENABLE_KTLS);
 #endif
     ssl_ctx = ctx;
@@ -238,9 +238,11 @@ static inline EVP_PKEY* generate_EC_pkey_with_NID(int nid=NID_secp384r1)
 
 static inline EVP_PKEY* generate_RSA_pkey(unsigned int bits = 2048)
 {
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+#if OPENSSL_VERSION_NUMBER > 0x30000000L
     return EVP_RSA_gen(bits);
 #else
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     RSA *rsa{nullptr};
     EVP_PKEY *pkey{nullptr};
     BIGNUM *bignum{nullptr};
@@ -262,6 +264,7 @@ static inline EVP_PKEY* generate_RSA_pkey(unsigned int bits = 2048)
     RSA_free(rsa);
     EVP_PKEY_free(pkey);
     return nullptr;
+#pragma GCC diagnostic pop
 #endif /* OpenSSL 3 or higher */
 }
 


### PR DESCRIPTION
OpenSSL development(alpha) versions for 3.0.0 release deprecated lot's
of previously supported APIs before adding the new ones.
Additionally, there is no simple way to distinguish between 3.0.0 alpha
and release versions since the OPENSSL_VERSION_NUMBER is of the same
value. Thus, the only reasonable solution seems to be the one where we
migrate to the OpenSSL 3 APIs for versions that after the 3.0.0.
Potential "API deprecated" warnings will be suppressed for previous
versions.

Signed-off-by: Alex Briskin <abriskin@nvidia.com>