### PR TITLE
issue 3109144: Add Unix Domain Socket support in SOCK_STREAM and SOCK_DGRAM

### DIFF
--- a/doc/main.dox
+++ b/doc/main.dox
@@ -115,8 +115,8 @@ sockperf: [tid 4805] using epoll() to block on socket(s)
    The following table describes Sockperf options, and their possible values:
 @code
  -h,-?   --help,--usage         -Show the help message and exit.
-         --tcp                  -Use TCP protocol (default UDP).
- -i      --ip                   -Listen on/send to ip <ip>.
+         --tcp --stream         -Use stream socket/TCP protocol (default dgram socket/UDP protocol).
+ -i      --ip --addr            -Listen on/send to ip <ip> or address <name>.
  -p      --port                 -Listen on/connect to port <port> (default 11111).
  -f      --file                 -Read list of connections from file (used in pair with -F option).
  -F      --iomux-type           -Type of multiple file descriptors handle [s|select|p|poll|e|epoll|r|recvfrom|x|socketxtreme](default epoll).
@@ -189,7 +189,7 @@ sockperf: [tid 4805] using epoll() to block on socket(s)
  -t      --time                 -Run for <sec> seconds (default 1, max = 36000000).
  -n      --number-of-packets    -Run for n packets sent and received (default 0, max = 100000000).
          --client_port          -Force the client side to bind to a specific port (default = 0).
-         --client_ip            -Force the client side to bind to a specific ip address (default = 0).
+         --client_addr          -Force the client side to bind to a specific address in IPv4, IPv6, UNIX domain socket format (default = 0).
  -b      --burst                -Control the client's number of a messages sent in every burst.
          --mps                  -Set number of messages-per-second (default = 10000 - for under-load mode, or max - for ping-pong and throughput modes; for maximum use --mps=max;
                                  support --pps for old compatibility).

--- a/doc/main.dox
+++ b/doc/main.dox
@@ -103,11 +103,14 @@ sockperf: [tid 4805] using epoll() to block on socket(s)
    [U|T]:address:port
    or
    [U|T]:address:port:mc_src_addr
+   or
+   [U|T]:PATH
    where
    - [U|T] - UDP or TCP protocol;
    - address - Internet Protocol (IP) address or host name (IPv6 addresses must be enclosed in square brackets);
    - port - Port number;
    - mc_src_addr - Optional multicast source IP address or host name.
+   - PATH - absolute path for UNIX Domain Socket, the line must start with '/'
 
 
 @subsection _option 3.1 Available options

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -55,11 +55,16 @@ std::string sockaddr_to_hostport(const struct sockaddr *addr)
     case AF_INET6:
         addrlen = sizeof(sockaddr_in6);
         break;
+    case AF_UNIX:
+        addrlen = sizeof(sockaddr_un);
+        break;
     }
     getnameinfo(addr, addrlen, hbuf, sizeof(hbuf), pbuf, sizeof(pbuf),
             NI_NUMERICHOST | NI_NUMERICSERV);
     if (addr->sa_family == AF_INET6) {
         return "[" + std::string(hbuf) + "]:" + std::string(pbuf);
+    } else if (addr->sa_family == AF_UNIX) {
+        return std::string(pbuf) + " [UNIX]";
     } else {
         return std::string(hbuf) + ":" + std::string(pbuf);
     }

--- a/src/common.h
+++ b/src/common.h
@@ -190,4 +190,25 @@ static inline void sockaddr_set_portn(sockaddr_store_t &addr, uint16_t port)
     }
 }
 
+static inline void copy_relevant_sockaddr_params(sockaddr_store_t &dst_addr, const sockaddr_store_t &src_addr)
+{
+    switch (src_addr.ss_family) {
+    case AF_INET:
+        dst_addr.addr4 = src_addr.addr4;
+    case AF_INET6:
+        dst_addr.addr6 = src_addr.addr6;
+    case AF_UNIX:
+        dst_addr.addr_un = src_addr.addr_un;
+    }
+}
+
+static inline std::string unix_sockaddr_to_string(const sockaddr_un *sa)
+{
+    std::string str(sa->sun_path, sizeof(sa->sun_path));
+    size_t len = str.find('\0');
+    if (len != std::string::npos)
+        str.resize(len);
+    return str;
+}
+
 #endif /* COMMON_H_ */

--- a/src/common.h
+++ b/src/common.h
@@ -211,4 +211,13 @@ static inline std::string unix_sockaddr_to_string(const sockaddr_un *sa)
     return str;
 }
 
+/**
+ * @brief
+ * @return build client socket address for UNIX sockets.
+ */
+static inline std::string build_client_socket_name(const sockaddr_un *sa, int pid, int ifd)
+{
+    return unix_sockaddr_to_string(sa) + "_" + std::to_string(pid) + "_" + std::to_string(ifd);
+}
+
 #endif /* COMMON_H_ */

--- a/src/defs.h
+++ b/src/defs.h
@@ -151,6 +151,8 @@ const uint32_t TEST_FIRST_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC = 50;
     "(:([a-zA-Z0-9\\.\\-]+|\\[([a-fA-F0-9.:]+)\\]))?[\r\n]"
 #define PRINT_PROTOCOL(type)                                                                       \
     ((type) == SOCK_DGRAM ? "UDP" : ((type) == SOCK_STREAM ? "TCP" : "<?>"))
+#define PRINT_SOCKET_TYPE(type)                                                                     \
+    ((type) == SOCK_DGRAM ? "SOCK_DGRAM" : ((type) == SOCK_STREAM ? "SOCK_STREAM" : "<?>"))
 
 #define MAX_ARGV_SIZE 256
 #define MAX_DURATION 36000000
@@ -209,7 +211,7 @@ enum {
     OPT_RECV_LOOPING,             // 34
     OPT_OUTPUT_PRECISION,         // 35
     OPT_CLIENTPORT,               // 36
-    OPT_CLIENTIP,                 // 37
+    OPT_CLIENTADDR,               // 37
     OPT_TOS,                      // 38
     OPT_LLS,                      // 39
     OPT_MC_SOURCE_IP,             // 40
@@ -478,6 +480,7 @@ struct sockaddr_store_t {
         sa_family_t ss_family;
         sockaddr_in addr4;
         sockaddr_in6 addr6;
+        sockaddr_un addr_un;
     };
 };
 

--- a/src/defs.h
+++ b/src/defs.h
@@ -625,80 +625,88 @@ typedef enum { // must be coordinated with s_fds_handle_desc in common.cpp
     FD_HANDLE_MAX } fd_block_handler_t;
 
 struct user_params_t {
-    work_mode_t mode; // either client or server
-    measurement_mode_t measurement; // either time or number
+    work_mode_t mode = MODE_SERVER; // either client or server
+    measurement_mode_t measurement = TIME_BASED; // either time or number
     IPAddress rx_mc_if_addr;
     IPAddress tx_mc_if_addr;
     IPAddress mc_source_ip_addr;
-    int msg_size;
-    int msg_size_range;
-    int sec_test_duration;
-    uint64_t number_test_target;
-    bool data_integrity;
-    fd_block_handler_t fd_handler_type;
-    unsigned int packetrate_stats_print_ratio;
-    unsigned int burst_size;
-    bool packetrate_stats_print_details;
-    //	bool stream_mode; - use b_stream instead
-    int mthread_server;
-    struct timeval *select_timeout;
-    int sock_buff_size;
-    int threads_num;
+    int msg_size = MIN_PAYLOAD_SIZE;
+    int msg_size_range = 0;
+    int sec_test_duration = DEFAULT_TEST_DURATION;
+    uint64_t number_test_target = DEFAULT_TEST_NUMBER;
+    bool data_integrity = false;
+    fd_block_handler_t fd_handler_type = RECVFROM;
+    unsigned int packetrate_stats_print_ratio = 0;
+    unsigned int burst_size = 1;
+    bool packetrate_stats_print_details = false;
+    int mthread_server = 0;
+    struct timeval *select_timeout = nullptr;
+    int sock_buff_size = SOCK_BUFF_DEFAULT_SIZE;
+    int threads_num = 1;
     char threads_affinity[MAX_ARGV_SIZE];
-    bool is_blocked;
-    bool do_warmup;
-    unsigned int pre_warmup_wait;
-    uint32_t cooldown_msec;
-    uint32_t warmup_msec;
-    uint64_t cooldown_num;
-    uint64_t warmup_num;
-    bool is_rxfiltercb;
-    bool is_zcopyread;
+    bool is_rxfiltercb = false;
+    bool is_zcopyread = false;
+    bool is_blocked = true;
+    bool do_warmup = true;
+    unsigned int pre_warmup_wait = 0;
+    uint32_t cooldown_msec = 0;
+    uint32_t warmup_msec = 0;
+    uint64_t cooldown_num = 0;
+    uint64_t warmup_num = 0;
+    bool is_vmarxfiltercb = false;
+    bool is_vmazcopyread = false;
     TicksDuration cycleDuration;
-    bool mc_loop_disable;
-    bool uc_reuseaddr;
-    int client_work_with_srv_num;
-    bool b_server_reply_via_uc;
-    bool b_server_dont_reply;
-    bool b_server_detect_gaps;
-    uint32_t mps; // client side only
+    bool mc_loop_disable = true;
+    bool uc_reuseaddr = false;
+    int client_work_with_srv_num = DEFAULT_CLIENT_WORK_WITH_SRV_NUM;
+    bool b_server_reply_via_uc = false;
+    bool b_server_dont_reply = false;
+    bool b_server_detect_gaps = false;
+    uint32_t mps = MPS_DEFAULT; // client side only
     struct sockaddr_store_t client_bind_info;
-    socklen_t client_bind_info_len;
-    uint32_t reply_every;    // client side only
-    bool b_client_ping_pong; // client side only
-    bool b_no_rdtsc;
+    socklen_t client_bind_info_len = 0;
+    uint32_t reply_every = REPLY_EVERY_DEFAULT;    // client side only
+    bool b_client_ping_pong = false; // client side only
+    bool b_no_rdtsc = false;
     char sender_affinity[MAX_ARGV_SIZE];
     char receiver_affinity[MAX_ARGV_SIZE];
-    FILE *fileFullLog;               // client side only
-    bool full_rtt;                   // client side only
-    bool giga_size;                  // client side only
-    bool increase_output_precision;  // client side only
-    bool b_stream;                   // client side only
-    PlaybackVector *pPlaybackVector; // client side only
-    uint32_t ci_significance_level;  // client side only
-    bool b_histogram;                // client side only
-    uint32_t histogram_lower_range;  // client side only
-    uint32_t histogram_upper_range;  // client side only
-    uint32_t histogram_bin_size;     // client side only
+    FILE *fileFullLog = NULL;                   // client side only
+    bool full_rtt = false;                      // client side only
+    bool giga_size = false;                     // client side only
+    bool increase_output_precision = false;     // client side only
+    bool b_stream = false;                      // client side only
+    PlaybackVector *pPlaybackVector = NULL;     // client side only
+    uint32_t ci_significance_level = DEFAULT_CI_SIG_LEVEL;// client side only
+    bool b_histogram;                           // client side only
+    uint32_t histogram_lower_range = 0;         // client side only
+    uint32_t histogram_upper_range = 2000000;   // client side only
+    uint32_t histogram_bin_size = 10;           // client side only
     struct sockaddr_store_t addr;
-    socklen_t addr_len;
-    int sock_type;
-    bool tcp_nodelay;
-    bool is_nonblocked_send;
-    int mc_ttl;
-    int daemonize;
+    socklen_t addr_len = 0;
+    int sock_type = SOCK_DGRAM;
+    bool tcp_nodelay = true;
+    bool is_nonblocked_send = false;
+    int mc_ttl = 2;
+    int daemonize = false;
     char feedfile_name[MAX_PATH_LENGTH];
-    bool withsock_accl;
-    int max_looping_over_recv;
-    int tos;
-    unsigned int lls_usecs;
-    bool lls_is_set;
-    uint32_t dummy_mps;                   // client side only
+    bool withsock_accl = false;
+    int max_looping_over_recv = 1;
+    int tos = 0x00;
+    unsigned int lls_usecs = 0;
+    bool lls_is_set = false;
+    uint32_t dummy_mps = 0;                   // client side only
     TicksDuration dummySendCycleDuration; // client side only
-    uint32_t rate_limit;
+    uint32_t rate_limit = 0;
 #if defined(DEFINED_TLS)
-    bool tls;
+    bool tls = false;
 #endif /* DEFINED_TLS */
+
+    user_params_t() {
+        memset(&client_bind_info, 0, sizeof(client_bind_info));
+        memset(&addr, 0, sizeof(addr));
+        memset(sender_affinity, 0, sizeof(sender_affinity));
+        memset(receiver_affinity, 0, sizeof(receiver_affinity));
+    }
 };
 
 struct mutable_params_t {};

--- a/src/defs.h
+++ b/src/defs.h
@@ -149,6 +149,10 @@ const uint32_t TEST_FIRST_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC = 50;
     "([a-zA-Z0-9\\.\\-]+|\\[([a-fA-F0-9.:]+(%[0-9a-zA-z])?)\\])"                                   \
     ":(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[0-5]?[0-9]{1,4})"                   \
     "(:([a-zA-Z0-9\\.\\-]+|\\[([a-fA-F0-9.:]+)\\]))?[\r\n]"
+
+#define UNIX_DOMAIN_SOCKET_FORMAT_REG_EXP                                                          \
+         "^[UuTt]:(/.+)[\r\n]"
+
 #define PRINT_PROTOCOL(type)                                                                       \
     ((type) == SOCK_DGRAM ? "UDP" : ((type) == SOCK_STREAM ? "TCP" : "<?>"))
 #define PRINT_SOCKET_TYPE(type)                                                                     \

--- a/src/iohandlers.cpp
+++ b/src/iohandlers.cpp
@@ -36,9 +36,13 @@ static void print_addresses(const fds_data *data, int &list_count)
         getnameinfo(reinterpret_cast<const sockaddr *>(&data->server_addr), data->server_addr_len,
                 hbuf, sizeof(hbuf), pbuf, sizeof(pbuf),
                 NI_NUMERICHOST | NI_NUMERICSERV);
-        printf("[%2d] IP = %-15s PORT = %5s # %s\n", list_count++,
-                hbuf, pbuf,
-                PRINT_PROTOCOL(data->sock_type));
+        switch (data->server_addr.ss_family) {
+            case AF_UNIX:
+                printf("[%2d] Address is %s # UDS type is %s\n", list_count++, pbuf, PRINT_SOCKET_TYPE(data->sock_type));
+                break;
+            default:
+                printf("[%2d] IP = %-15s PORT = %5s # %s\n", list_count++, hbuf, pbuf, PRINT_PROTOCOL(data->sock_type));
+        }
     }
     for (int i = 0; i < data->memberships_size; i++) {
         char hbuf[NI_MAXHOST] = "(unknown)";

--- a/src/server.h
+++ b/src/server.h
@@ -282,13 +282,13 @@ inline bool Server<IoType, SwitchActivityInfo, SwitchCalcGaps>::handle_message(i
             m_pMsgReply->setServer();
         }
         /* get source addr to reply. memcpy is not used to improve performance */
-        sendto_addr = l_fds_ifd->server_addr;
+        copy_relevant_sockaddr_params(sendto_addr, l_fds_ifd->server_addr);
         sendto_addr_len = l_fds_ifd->server_addr_len;
 
         if (l_fds_ifd->memberships_size || !l_fds_ifd->is_multicast ||
             g_pApp->m_const_params.b_server_reply_via_uc) { // In unicast case reply to sender
             /* get source addr to reply. memcpy is not used to improve performance */
-            sendto_addr = recvfrom_addr;
+            copy_relevant_sockaddr_params(sendto_addr, recvfrom_addr);
             sendto_addr_len = recvfrom_len;
         } else if (l_fds_ifd->is_multicast) {
             /* always send to the same port recved from */

--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -2402,76 +2402,19 @@ void set_defaults() {
     int igmp_max_memberships = read_int_from_sys_file("/proc/sys/net/ipv4/igmp_max_memberships");
     if (igmp_max_memberships != -1) IGMP_MAX_MEMBERSHIPS = igmp_max_memberships;
 
-    memset((void *)&s_user_params, 0, sizeof(s_user_params));
     memset(g_fds_array, 0, sizeof(fds_data *) * MAX_FDS_NUM);
     s_user_params.rx_mc_if_addr = IPAddress::zero();
     s_user_params.tx_mc_if_addr = IPAddress::zero();
     s_user_params.mc_source_ip_addr = IPAddress::zero();
-    s_user_params.sec_test_duration = DEFAULT_TEST_DURATION;
-    s_user_params.number_test_target = DEFAULT_TEST_NUMBER;
     s_user_params.client_bind_info.ss_family = AF_UNSPEC;
-    s_user_params.ci_significance_level = DEFAULT_CI_SIG_LEVEL;
-    s_user_params.mode = MODE_SERVER;
-    s_user_params.measurement = TIME_BASED;
-    s_user_params.packetrate_stats_print_ratio = 0;
-    s_user_params.packetrate_stats_print_details = false;
-    s_user_params.burst_size = 1;
-    s_user_params.data_integrity = false;
-    s_user_params.fd_handler_type = RECVFROM;
-    s_user_params.mthread_server = 0;
-    s_user_params.msg_size = MIN_PAYLOAD_SIZE;
-    s_user_params.msg_size_range = 0;
-    s_user_params.sock_buff_size = SOCK_BUFF_DEFAULT_SIZE;
+
     set_select_timeout(DEFAULT_SELECT_TIMEOUT_MSEC);
-    s_user_params.threads_num = 1;
     memset(s_user_params.threads_affinity, 0, sizeof(s_user_params.threads_affinity));
-    s_user_params.is_blocked = true;
-    s_user_params.is_nonblocked_send = false;
-    s_user_params.max_looping_over_recv = 1;
-    s_user_params.do_warmup = true;
-    s_user_params.pre_warmup_wait = 0;
-    s_user_params.is_rxfiltercb = false;
-    s_user_params.is_zcopyread = false;
+
     g_debug_level = LOG_LVL_INFO;
-    s_user_params.mc_loop_disable = true;
-    s_user_params.uc_reuseaddr = false;
-    s_user_params.client_work_with_srv_num = DEFAULT_CLIENT_WORK_WITH_SRV_NUM;
-    s_user_params.b_server_reply_via_uc = false;
-    s_user_params.b_server_dont_reply = false;
-    s_user_params.b_server_detect_gaps = false;
 
-    s_user_params.histogram_lower_range = 0;
-    s_user_params.histogram_upper_range = 2000000;
-    s_user_params.histogram_bin_size = 10;
-
-    s_user_params.mps = MPS_DEFAULT;
-    s_user_params.reply_every = REPLY_EVERY_DEFAULT;
-    s_user_params.b_client_ping_pong = false;
-    s_user_params.b_no_rdtsc = false;
-    memset(s_user_params.sender_affinity, 0, sizeof(s_user_params.sender_affinity));
-    memset(s_user_params.receiver_affinity, 0, sizeof(s_user_params.receiver_affinity));
-    // s_user_params.b_load_vma = false;
-    s_user_params.fileFullLog = NULL;
-    s_user_params.b_stream = false;
-    s_user_params.full_rtt = false;
-    s_user_params.giga_size = false;
-    s_user_params.increase_output_precision = false;
-    s_user_params.pPlaybackVector = NULL;
-
-    s_user_params.sock_type = SOCK_DGRAM;
-    s_user_params.tcp_nodelay = true;
-    s_user_params.mc_ttl = 2;
-
-    s_user_params.daemonize = false;
-
-    s_user_params.withsock_accl = false;
-    s_user_params.dummy_mps = 0;
     memset(s_user_params.feedfile_name, 0, sizeof(s_user_params.feedfile_name));
-    s_user_params.tos = 0x00;
 
-#if defined(DEFINED_TLS)
-    s_user_params.tls = false;
-#endif /* DEFINED_TLS */
 }
 
 //------------------------------------------------------------------------------

--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -176,8 +176,8 @@ static const AOPT_DESC common_opt_desc[] = {
       aopt_set_literal('h', '?'),       aopt_set_string("help", "usage"),
       "Show the help message and exit." },
     { OPT_TCP,                AOPT_NOARG,                       aopt_set_literal(0),
-      aopt_set_string("tcp"), "Use TCP protocol (default UDP)." },
-    { 'i', AOPT_ARG, aopt_set_literal('i'), aopt_set_string("ip"), "Listen on/send to ip <ip>." },
+      aopt_set_string("tcp", "stream"), "Use stream socket/TCP protocol (default dgram socket/UDP protocol)." },
+    { 'i', AOPT_ARG, aopt_set_literal('i'), aopt_set_string("addr", "ip"), "Listen on/send to address in IPv4, IPv6, UNIX domain socket format"},
     { 'p',                                                AOPT_ARG,
       aopt_set_literal('p'),                              aopt_set_string("port"),
       "Listen on/connect to port <port> (default 11111)." },
@@ -397,12 +397,12 @@ static int parse_client_bind_info(const AOPT_OBJECT *common_obj, const AOPT_OBJE
             }
         }
 
-        if (!rc && aopt_check(self_obj, OPT_CLIENTIP)) {
-            const char *optarg = aopt_value(self_obj, OPT_CLIENTIP);
+        if (!rc && aopt_check(self_obj, OPT_CLIENTADDR)) {
+            const char *optarg = aopt_value(self_obj, OPT_CLIENTADDR);
             if (optarg) {
                 host_str = optarg;
             } else {
-                log_msg("'--client_ip' Invalid address");
+                log_msg("'--client_addr' Invalid address");
                 rc = SOCKPERF_ERR_BAD_ARGUMENT;
             }
         }
@@ -413,7 +413,7 @@ static int parse_client_bind_info(const AOPT_OBJECT *common_obj, const AOPT_OBJE
                 true, reinterpret_cast<sockaddr*>(&s_user_params.client_bind_info),
                 s_user_params.client_bind_info_len);
         if (res != 0) {
-            log_msg("'--client_ip/--client_port': invalid host:port values: %s\n",
+            log_msg("'--client_addr/--client_port': invalid host:port values: %s\n",
                 gai_strerror(res));
             rc = SOCKPERF_ERR_BAD_ARGUMENT;
         }
@@ -441,11 +441,11 @@ static int proc_mode_under_load(int id, int argc, const char **argv) {
           aopt_set_literal(0),
           aopt_set_string("client_port"),
           "Force the client side to bind to a specific port (default = 0). " },
-        { OPT_CLIENTIP,
+        { OPT_CLIENTADDR,
           AOPT_ARG,
           aopt_set_literal(0),
-          aopt_set_string("client_ip"),
-          "Force the client side to bind to a specific ip address (default = 0). " },
+          aopt_set_string("client_ip", "client_addr"),
+          "Force the client side to bind to a specific address in IPv4, IPv6, UNIX domain socket format (default = 0). " },
         { 'b',                                                             AOPT_ARG,
           aopt_set_literal('b'),                                           aopt_set_string("burst"),
           "Control the client's number of a messages sent in every burst." },
@@ -697,7 +697,7 @@ static int proc_mode_under_load(int id, int argc, const char **argv) {
         printf("\n");
         printf("Usage: " MODULE_NAME " %s [options] [args]...\n", sockperf_modes[id].name);
         printf(" " MODULE_NAME
-               " %s -i ip  [-p port] [-m message_size] [-t time] [--data_integrity]\n",
+               " %s -i ip / --addr address [-p port] [-m message_size] [-t time] [--data_integrity]\n",
                sockperf_modes[id].name);
         printf(" " MODULE_NAME
                " %s -f file [-F s/p/e] [-m message_size] [-r msg_size_range] [-t time]\n",
@@ -753,11 +753,11 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
           aopt_set_literal(0),
           aopt_set_string("client_port"),
           "Force the client side to bind to a specific port (default = 0). " },
-        { OPT_CLIENTIP,
+        { OPT_CLIENTADDR,
           AOPT_ARG,
           aopt_set_literal(0),
-          aopt_set_string("client_ip"),
-          "Force the client side to bind to a specific ip address (default = 0). " },
+          aopt_set_string("client_ip", "client_addr"),
+          "Force the client side to bind to a specific address in IPv4, IPv6, UNIX domain socket format (default = 0). " },
         { 'b',                                                             AOPT_ARG,
           aopt_set_literal('b'),                                           aopt_set_string("burst"),
           "Control the client's number of a messages sent in every burst." },
@@ -1028,7 +1028,7 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
         printf("%s: %s\n", display_opt(id, temp_buf, sizeof(temp_buf)), sockperf_modes[id].note);
         printf("\n");
         printf("Usage: " MODULE_NAME " %s [options] [args]...\n", sockperf_modes[id].name);
-        printf(" " MODULE_NAME " %s -i ip  [-p port] [-m message_size] [-t time | -n number-of-packets]\n",
+        printf(" " MODULE_NAME " %s -i ip / --addr address [-p port] [-m message_size] [-t time | -n number-of-packets]\n",
                sockperf_modes[id].name);
         printf(" " MODULE_NAME
                " %s -f file [-F s/p/e] [-m message_size] [-r msg_size_range] [-t time | -n number-of-packets]\n",
@@ -1087,11 +1087,11 @@ static int proc_mode_throughput(int id, int argc, const char **argv) {
           aopt_set_literal(0),
           aopt_set_string("client_port"),
           "Force the client side to bind to a specific port (default = 0). " },
-        { OPT_CLIENTIP,
+        { OPT_CLIENTADDR,
           AOPT_ARG,
           aopt_set_literal(0),
-          aopt_set_string("client_ip"),
-          "Force the client side to bind to a specific ip address (default = 0). " },
+          aopt_set_string("client_ip", "client_addr"),
+          "Force the client side to bind to a specific address in IPv4, IPv6, UNIX domain socket format (default = 0). " },
         { 'b',                                                             AOPT_ARG,
           aopt_set_literal('b'),                                           aopt_set_string("burst"),
           "Control the client's number of a messages sent in every burst." },
@@ -1263,7 +1263,7 @@ static int proc_mode_throughput(int id, int argc, const char **argv) {
         printf("%s: %s\n", display_opt(id, temp_buf, sizeof(temp_buf)), sockperf_modes[id].note);
         printf("\n");
         printf("Usage: " MODULE_NAME " %s [options] [args]...\n", sockperf_modes[id].name);
-        printf(" " MODULE_NAME " %s -i ip  [-p port] [-m message_size] [-t time]\n",
+        printf(" " MODULE_NAME " %s -i ip / --addr address [-p port] [-m message_size] [-t time]\n",
                sockperf_modes[id].name);
         printf(" " MODULE_NAME
                " %s -f file [-F s/p/e] [-m message_size] [-r msg_size_range] [-t time]\n",
@@ -1463,7 +1463,7 @@ static int proc_mode_playback(int id, int argc, const char **argv) {
         printf("%s: %s\n", display_opt(id, temp_buf, sizeof(temp_buf)), sockperf_modes[id].note);
         printf("\n");
         printf("Usage: " MODULE_NAME " %s [options] [args]...\n", sockperf_modes[id].name);
-        printf(" " MODULE_NAME " %s -i ip  [-p port] --data-file playback.csv\n",
+        printf(" " MODULE_NAME " %s -i ip / --addr address [-p port] --data-file playback.csv\n",
                sockperf_modes[id].name);
         printf("\n");
         printf("Options:\n");
@@ -1657,7 +1657,7 @@ static int proc_mode_server(int id, int argc, const char **argv) {
         printf("Usage: " MODULE_NAME " %s [options] [args]...\n", sockperf_modes[id].name);
         printf(" " MODULE_NAME " %s\n", sockperf_modes[id].name);
         printf(" " MODULE_NAME
-               " %s [-i ip] [-p port] [--mc-rx-if ip] [--mc-tx-if ip] [--mc-source-filter ip]\n",
+               " %s [-i ip / --addr address] [-p port] [--mc-rx-if ip] [--mc-tx-if ip] [--mc-source-filter ip]\n",
                sockperf_modes[id].name);
 #ifndef WIN32
         printf(" " MODULE_NAME
@@ -1728,9 +1728,27 @@ static int resolve_sockaddr(const char *host, const char *port, int sock_type,
     // any protocol
     hints.ai_protocol = 0;
     hints.ai_socktype = sock_type;
-
+    int res;
     struct addrinfo *result;
-    int res = getaddrinfo(host, port, &hints, &result);
+
+    if (host != NULL) {
+        std::string path = host;
+        struct sockaddr_store_t *tmp = ((sockaddr_store_t *)addr);
+        if (path.size() > 0 && path[0] == '/') {
+            log_dbg("provided path for Unix Domain Socket is %s\n", host);
+            if (path.length() > MAX_UDS_NAME) {
+                log_err("length of name is larger than %d bytes", MAX_UDS_NAME);
+                res = SOCKPERF_ERR_SOCKET;
+                return res;
+            }
+            addr_len = sizeof(struct sockaddr_un);
+            strncpy(tmp->addr_un.sun_path, path.c_str(), MAX_UDS_NAME);
+            tmp->ss_family = AF_UNIX;
+
+            return 0;
+        }
+    }
+    res = getaddrinfo(host, port, &hints, &result);
     if (res == 0) {
         get_socket_address(result, addr, addr_len);
         freeaddrinfo(result);
@@ -2329,6 +2347,11 @@ void cleanup() {
                 if (g_fds_array[ifd]->is_multicast) {
                     FREE(g_fds_array[ifd]->memberships_addr);
                 }
+                if (s_user_params.addr.ss_family == AF_UNIX) {
+                    if (s_user_params.mode == MODE_SERVER)
+                        unlink(s_user_params.addr.addr_un.sun_path);
+                    unlink(s_user_params.client_bind_info.addr_un.sun_path);
+                }
                 delete g_fds_array[ifd];
             }
         }
@@ -2517,7 +2540,7 @@ inline bool CallbackMessageHandler::handle_message()
             msgReply->setServer();
         }
         /* get source addr to reply. memcpy is not used to improve performance */
-        sendto_addr = m_fds_ifd->server_addr;
+        copy_relevant_sockaddr_params(sendto_addr, m_fds_ifd->server_addr);
         sendto_len = m_fds_ifd->server_addr_len;
 
         if (m_fds_ifd->memberships_size || !m_fds_ifd->is_multicast ||
@@ -3020,7 +3043,7 @@ static int set_sockets_from_feedfile(const char *feedfile_name) {
             if (s_user_params.fd_handler_type == SOCKETXTREME &&
                 is_unspec_addr(s_user_params.client_bind_info)) {
                 log_msg("socketxtreme requires forcing the client side to bind to a specific ip "
-                        "address (use --client_ip) option");
+                        "address (use --client_ip/--client_addr) option");
                 rc = SOCKPERF_ERR_INCORRECT;
                 break;
             }
@@ -3323,6 +3346,24 @@ int bringup(const int *p_daemonize) {
 
             std::unique_ptr<fds_data> tmp{ new fds_data };
 
+            if (s_user_params.addr.ss_family == AF_UNIX) {
+                log_dbg("UNIX domain socket was provided %s\n", s_user_params.addr.addr_un.sun_path);
+                s_user_params.tcp_nodelay = false;
+                if (s_user_params.sock_type == SOCK_DGRAM) { // Need to bind localy
+                    s_user_params.client_bind_info.ss_family = AF_UNIX;
+                    if (s_user_params.client_bind_info.addr_un.sun_path[0] == 0 && s_user_params.mode == MODE_CLIENT) { // no specific addr client_info was provoided
+                        log_dbg("No client name was provided, setting addr_un.sun_path to %s_client\n",s_user_params.addr.addr_un.sun_path);
+                        std::string sun_path = s_user_params.addr.addr_un.sun_path;
+                        sun_path += "_client";
+                        if (sun_path.length() > MAX_UDS_NAME) {
+                            log_err("length of name is larger than %d bytes", MAX_UDS_NAME);
+                            rc = SOCKPERF_ERR_SOCKET;
+                        } else
+                            strncpy(s_user_params.client_bind_info.addr_un.sun_path, sun_path.c_str(), MAX_UDS_NAME);
+                    }
+                    s_user_params.client_bind_info_len = sizeof(struct sockaddr_store_t);
+                }
+            }
             memcpy(&tmp->server_addr, &(s_user_params.addr), sizeof(s_user_params.addr));
             tmp->server_addr_len = s_user_params.addr_len;
             tmp->mc_source_ip_addr = s_user_params.mc_source_ip_addr;
@@ -3338,13 +3379,13 @@ int bringup(const int *p_daemonize) {
                 /* create a socket */
                 if ((curr_fd = (int)socket(tmp->server_addr.ss_family, tmp->sock_type, 0)) <
                     0) { // TODO: use SOCKET all over the way and avoid this cast
-                    log_err("socket(AF_INET4/6, SOCK_x)");
+                    log_err("socket(AF_INET4/6/AF_UNIX, SOCK_x)");
                     rc = SOCKPERF_ERR_SOCKET;
                 } else {
                     if ((curr_fd >= MAX_FDS_NUM) ||
                         (prepare_socket(curr_fd, tmp.get()) ==
-                         (int)INVALID_SOCKET)) { // TODO: use SOCKET all over the way and avoid
-                                                 // this cast
+                        (int)INVALID_SOCKET)) { // TODO: use SOCKET all over the way and avoid
+                                                // this cast
                         log_err("Invalid socket");
                         close(curr_fd);
                         rc = SOCKPERF_ERR_SOCKET;


### PR DESCRIPTION
Adding Unix Domain Socket support in SOCK_STREAM and SOCK_DGRAM
Signed-off-by: Eldar Shalev <eldarsh@nvidia.com>
Author:    Eldar Shalev <eldarsh@nvidia.com>

Adding new support for Unix Domain Socket on 2 modes - SOCK_STREAM and SOCK_DGRAM.
Binding automatically to the given path with suffix  "_client" or override using "--client_addr" as a parameter.
Example:
server side:
sockperf sr --addr PATH_TO_UDS_NAME
client side:
option 1: sockperf pp --addr PATH_TO_UDS_NAME
option 2: sockperf pp --addr PATH_TO_UDS_NAME --client_addr BINDING_NAME

Notes:
* Defualt is SOCK_DGRAM, for SOCK_STREAM use '--tcp'
* '--addr' was added in addition to '--ip'
* '--client_addr' was added in addition to '--client_ip'