### PR TITLE
issue: 3112201 Add the ability to load and configure XLIO library

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -49,7 +49,7 @@ sockperf_SOURCES = \
 	src/ticks_os.h \
 	src/tls.cpp \
 	src/tls.h \
-	src/vma-redirect.cpp \
+	src/vma-xlio-redirect.cpp \
 	src/vma-redirect.h
 
 dist_doc_DATA = \

--- a/configure.ac
+++ b/configure.ac
@@ -81,13 +81,26 @@ SP_CHECK_CXXFLAGS_APPEND([OUR_CXXFLAGS], [\
 AC_ARG_ENABLE(
     [vma-api],
     AC_HELP_STRING([--enable-vma-api],
-                   [SOCKPERF: enable vma extra api support (default=no)]),
+                   [SOCKPERF: enable vma extra api support: 'yes', 'no' or library installation path (default=no)]),
     [have_vma_api=$enableval],
     [have_vma_api=no])
-AS_IF([test "x${have_vma_api}" == "xyes"],
-    [AC_CHECK_HEADER([mellanox/vma_extra.h],
+AS_IF([test "${have_vma_api}" != "no"],
+    [
+    if test "$have_vma_api" = "yes"
+    then
+        have_vma_api=/usr
+    fi
+    CPPFLAGS="$CPPFLAGS -I$have_vma_api/include"
+    if test -d "$have_vma_api/lib64"
+    then
+        LDFLAGS="$LDFLAGS -L$have_vma_api/lib64"
+    else
+        LDFLAGS="$LDFLAGS -L$have_vma_api/lib"
+    fi
+
+    AC_CHECK_HEADER([mellanox/vma_extra.h],
         [AC_DEFINE([USING_VMA_EXTRA_API],[1],[[Enable using VMA extra API]])],
-        [AC_MSG_ERROR([vma_extra.h file not found])]
+        [AC_MSG_ERROR([vma_extra.h file not found at $have_vma_api/include])]
         [have_vma_api=no])])
 AC_MSG_CHECKING(
     [for vma extra api])

--- a/doc/main.dox
+++ b/doc/main.dox
@@ -136,13 +136,15 @@ sockperf: [tid 4805] using epoll() to block on socket(s)
          --lls                  -Turn on LLS via socket option (value = usec to poll).
          --buffer-size          -Set total socket receive/send buffer <size> in bytes (system defined by default).
          --nonblocked           -Open non-blocked sockets.
-         --recv_looping_num     -Set Sockperf to loop over recvfrom() until EAGAIN or <N> good received packets, -1 for infinite, must be used with --nonblocked (default 1).
+         --recv_looping_num     -Set sockperf to loop over recvfrom() until EAGAIN or <N> good received packets, -1 for infinite, must be used with --nonblocked (default 1).
          --dontwarmup           -Don't send warm up messages on start.
          --pre-warmup-wait      -Time to wait before sending warm up messages (seconds).
-         --vmazcopyread         -Use VMA's zero copy reads API (See VMA's readme).
+         --zcopyread,--vmazcopyread
+                                -Use VMA's zero copy reads API (See VMA's readme).
          --daemonize            -Run as daemon.
          --no-rdtsc             -Don't use register when taking time; instead use monotonic clock.
          --load-vma             -Load VMA dynamically even when LD_PRELOAD was not used.
+         --load-xlio            -Load XLIO dynamically even when LD_PRELOAD was not used.
          --rate-limit           -use rate limit (packet-pacing), with VMA must be run with VMA_RING_ALLOCATION_LOGIC_TX mode.
          --set-sock-accl        -Set socket acceleration before run (available for some of Mellanox systems)
  -d      --debug                -Print extra debug information.
@@ -154,7 +156,8 @@ sockperf: [tid 4805] using epoll() to block on socket(s)
 @code
          --threads-num          -Run <N> threads on server side (requires '-f' option).
          --cpu-affinity         -Set threads affinity to the given core ids in list format (see: cat /proc/cpuinfo).
-         --vmarxfiltercb        -Use VMA's receive path message filter callback API (See VMA's readme).
+         --rxfiltercb,--vmarxfiltercb
+                                -Use VMA's receive path message filter callback API (See VMA's readme).
          --force-unicast-reply  -Force server to reply via unicast.
          --dont-reply           -Server won't reply to the client messages.
  -m      --msg-size             -Set maximum message size that the server can receive <size> bytes (default 65507).
@@ -177,12 +180,14 @@ sockperf: [tid 4805] using epoll() to block on socket(s)
          --sender-affinity      -Set sender thread affinity to the given core ids in list format (see: cat /proc/cpuinfo).
          --receiver-affinity    -Set receiver thread affinity to the given core ids in list format (see: cat /proc/cpuinfo).
          --full-log             -Dump full log of all messages send/receive time to the given file in CSV format.
+         --full-rtt             -Show results in round-trip-time instead of latency.
          --giga-size            -Print sizes in GigaByte.
          --increase_output_precision
                                 -Increase number of digits after decimal point of the throughput output (from 3 to 9).
          --dummy-send           -Use VMA's dummy send API instead of busy wait, must be higher than regular msg rate.
                                  optional: set dummy-send rate per second (default 10,000), usage: --dummy-send [<rate>|max]
  -t      --time                 -Run for <sec> seconds (default 1, max = 36000000).
+ -n      --number-of-packets    -Run for n packets sent and received (default 0, max = 100000000).
          --client_port          -Force the client side to bind to a specific port (default = 0).
          --client_ip            -Force the client side to bind to a specific ip address (default = 0).
  -b      --burst                -Control the client's number of a messages sent in every burst.
@@ -190,7 +195,9 @@ sockperf: [tid 4805] using epoll() to block on socket(s)
                                  support --pps for old compatibility).
  -m      --msg-size             -Use messages of size <size> bytes (minimum default 14).
  -r      --range                -comes with -m <size>, randomly change the messages size in range: <size> +- <N>.
-         --data-integrity       -Perform data integrity test
+         --data-integrity       -Perform data integrity test.
+         --ci_sig_level         -Normal confidence interval significance level for stat reported. Values are between 0 and 100 exclusive (default 99).
+         --histogram            -Build histogram of latencies. Histogram arguments formated as binsize:lowerrange:upperrange
 @endcode
 
 @subsection _tool 3.4 Tools

--- a/src/client.h
+++ b/src/client.h
@@ -203,7 +203,7 @@ private:
 #ifdef USING_VMA_EXTRA_API
         if (SOCKETXTREME == g_pApp->m_const_params.fd_handler_type) {
             return client_receive_from_selected<SocketXtremeInputHandler>(ifd);
-        } else if (g_pApp->m_const_params.is_vmazcopyread) {
+        } else if (g_pApp->m_const_params.is_zcopyread) {
             return client_receive_from_selected<VmaZCopyReadInputHandler>(ifd);
         } else
 #endif

--- a/src/defs.h
+++ b/src/defs.h
@@ -95,7 +95,7 @@
 #include "ip_address.h"
 
 #if !defined(WIN32) && !defined(__FreeBSD__)
-#include "vma-redirect.h"
+#include "vma-xlio-redirect.h"
 #ifdef USING_VMA_EXTRA_API
 #include <mellanox/vma_extra.h>
 #endif
@@ -219,6 +219,7 @@ enum {
     OPT_FULL_RTT,                 // 44
     OPT_CI_SIG_LVL,               // 45
     OPT_HISTOGRAM,                // 46
+    OPT_LOAD_XLIO,                // 47
 #if defined(DEFINED_TLS)
     OPT_TLS
 #endif /* DEFINED_TLS */

--- a/src/defs.h
+++ b/src/defs.h
@@ -184,8 +184,8 @@ enum {
     OPT_NONBLOCKED,               // 9
     OPT_DONTWARMUP,               // 10
     OPT_PREWARMUPWAIT,            // 11
-    OPT_VMARXFILTERCB,            // 12
-    OPT_VMAZCOPYREAD,             // 13
+    OPT_RXFILTERCB,               // 12
+    OPT_ZCOPYREAD,                // 13
     OPT_SOCKETXTREME,             // 14
     OPT_MC_LOOPBACK_ENABLE,       // 15
     OPT_CLIENT_WORK_WITH_SRV_NUM, // 16
@@ -652,8 +652,8 @@ struct user_params_t {
     uint32_t warmup_msec;
     uint64_t cooldown_num;
     uint64_t warmup_num;
-    bool is_vmarxfiltercb;
-    bool is_vmazcopyread;
+    bool is_rxfiltercb;
+    bool is_zcopyread;
     TicksDuration cycleDuration;
     bool mc_loop_disable;
     bool uc_reuseaddr;

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -98,8 +98,8 @@ Message::Message() {
     /*
         log_msg("ms_maxSize=%d, m_buf=%p, alignment=%d, m_data=%p, m_header=%p", ms_maxSize, m_buf,
     alignment, m_data, m_header);
-        log_msg("header adresses: m_sequence_number=%p", &m_header->m_sequence_number);
-    //*/
+        log_msg("header addresses: m_sequence_number=%p", &m_header->m_sequence_number);
+    */
 }
 
 //------------------------------------------------------------------------------

--- a/src/message_parser.h
+++ b/src/message_parser.h
@@ -44,7 +44,9 @@ public:
     }
 
     /** Process next buffer
-     * @param [in/out] recv_data receive stream context
+     * @param [inout] callback object to invoke handle_message method when
+     *      message is ready to be processed
+     * @param [inout] recv_data receive stream context
      * @param [in] buf buffer start
      * @param [in] len buffer length
      * @return false on message parsing or processing error, otherwise true

--- a/src/packet.cpp
+++ b/src/packet.cpp
@@ -49,7 +49,7 @@ PacketTimes::PacketTimes(uint64_t _maxSequenceNo, uint64_t _replyEvery, uint64_t
                 , m_pInternalUse
                 , m_pErrors, _numServers
                 );
-    //*/
+    */
 }
 
 PacketTimes::~PacketTimes() {

--- a/src/server.h
+++ b/src/server.h
@@ -128,7 +128,7 @@ public:
 #ifdef USING_VMA_EXTRA_API
         if (SOCKETXTREME == g_pApp->m_const_params.fd_handler_type) {
             return server_receive_then_send<SocketXtremeInputHandler>(ifd);
-        } else if (g_pApp->m_const_params.is_vmazcopyread) {
+        } else if (g_pApp->m_const_params.is_zcopyread) {
             return server_receive_then_send<VmaZCopyReadInputHandler>(ifd);
         } else
 #endif

--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -229,10 +229,10 @@ static const AOPT_DESC common_opt_desc[] = {
       "Enables non-blocking send operation (default OFF)." },
     { OPT_TOS, AOPT_ARG, aopt_set_literal(0), aopt_set_string("tos"), "Allows setting tos" },
     { OPT_RX_MC_IF, AOPT_ARG, aopt_set_literal(0), aopt_set_string("mc-rx-if"),
-      "Set address <ip> of interface on which to receive mulitcast messages (can be other then "
+      "Set address <ip> of interface on which to receive multicast messages (can be other then "
       "route table)." },
     { OPT_TX_MC_IF, AOPT_ARG, aopt_set_literal(0), aopt_set_string("mc-tx-if"),
-      "Set address <ip> of interface on which to transmit mulitcast messages (can be other then "
+      "Set address <ip> of interface on which to transmit multicast messages (can be other then "
       "route table)." },
     { OPT_MC_LOOPBACK_ENABLE,                   AOPT_NOARG,
       aopt_set_literal(0),                      aopt_set_string("mc-loopback-enable"),
@@ -244,7 +244,7 @@ static const AOPT_DESC common_opt_desc[] = {
       AOPT_ARG,
       aopt_set_literal(0),
       aopt_set_string("mc-source-filter"),
-      "Set address <ip, hostname> of mulitcast messages source which is allowed to receive from." },
+      "Set address <ip, hostname> of multicast messages source which is allowed to receive from." },
     { OPT_UC_REUSEADDR,                                   AOPT_NOARG,
       aopt_set_literal(0),                                aopt_set_string("uc-reuseaddr"),
       "Enables unicast reuse address (default disabled)." },
@@ -267,8 +267,8 @@ static const AOPT_DESC common_opt_desc[] = {
       aopt_set_literal(0),                                      aopt_set_string("pre-warmup-wait"),
       "Time to wait before sending warm up messages (seconds)." },
 #ifndef WIN32
-    { OPT_VMAZCOPYREAD,                                   AOPT_NOARG,
-      aopt_set_literal(0),                                aopt_set_string("vmazcopyread"),
+    { OPT_ZCOPYREAD,                                      AOPT_NOARG,
+      aopt_set_literal(0),                                aopt_set_string("zcopyread", "vmazcopyread"),
       "Use VMA's zero copy reads API (See VMA's readme)." },
     { OPT_DAEMONIZE, AOPT_NOARG, aopt_set_literal(0), aopt_set_string("daemonize"), "Run as "
                                                                                     "daemon." },
@@ -291,7 +291,7 @@ static const AOPT_DESC common_opt_desc[] = {
       AOPT_NOARG,
       aopt_set_literal(0),
       aopt_set_string("set-sock-accl"),
-      "Set socket accleration before run (available for some of Mellanox systems)" },
+      "Set socket acceleration before run (available for some of Mellanox systems)" },
 #if defined(DEFINED_TLS)
     { OPT_TLS,                AOPT_OPTARG,                                    aopt_set_literal(0),
       aopt_set_string("tls"), "Use TLSv1.2 (default " TLS_CHIPER_DEFAULT ")." },
@@ -1519,10 +1519,10 @@ static int proc_mode_server(int id, int argc, const char **argv) {
           aopt_set_string("cpu-affinity"),
           "Set threads affinity to the given core ids in list format (see: cat /proc/cpuinfo)." },
 #ifndef WIN32
-        { OPT_VMARXFILTERCB,
+        { OPT_RXFILTERCB,
           AOPT_NOARG,
           aopt_set_literal(0),
-          aopt_set_string("vmarxfiltercb"),
+          aopt_set_string("rxfiltercb", "vmarxfiltercb"),
           "Use VMA's receive path message filter callback API (See VMA's readme)." },
 #endif
         { OPT_FORCE_UC_REPLY,                  AOPT_NOARG,
@@ -1614,8 +1614,8 @@ static int proc_mode_server(int id, int argc, const char **argv) {
             }
         }
 #ifndef WIN32
-        if (!rc && aopt_check(server_obj, OPT_VMARXFILTERCB)) {
-            s_user_params.is_vmarxfiltercb = true;
+        if (!rc && aopt_check(server_obj, OPT_RXFILTERCB)) {
+            s_user_params.is_rxfiltercb = true;
         }
 #endif
 
@@ -2061,8 +2061,8 @@ static int parse_common_opt(const AOPT_OBJECT *common_obj) {
         }
 #ifndef WIN32
 
-        if (!rc && aopt_check(common_obj, OPT_VMAZCOPYREAD)) {
-            s_user_params.is_vmazcopyread = true;
+        if (!rc && aopt_check(common_obj, OPT_ZCOPYREAD)) {
+            s_user_params.is_zcopyread = true;
         }
 
         if (!rc && aopt_check(common_obj, OPT_DAEMONIZE)) {
@@ -2304,7 +2304,7 @@ static char *display_opt(int id, char *buf, size_t buf_size) {
 }
 
 //#define ST_TEST
-// use it with command such as: VMA ./sockperf -s -f conf/conf.inp --vmarxfiltercb
+// use it with command such as: VMA ./sockperf -s -f conf/conf.inp --rxfiltercb
 
 #ifdef ST_TEST
 static int st1, st2;
@@ -2338,7 +2338,7 @@ void cleanup() {
         FREE(s_user_params.select_timeout);
     }
 #ifdef USING_VMA_EXTRA_API
-    if (g_vma_api && s_user_params.is_vmazcopyread) {
+    if (g_vma_api && s_user_params.is_zcopyread) {
         zeroCopyMap::iterator it;
         while ((it = g_zeroCopyData.begin()) != g_zeroCopyData.end()) {
             delete it->second;
@@ -2430,8 +2430,8 @@ void set_defaults() {
     s_user_params.max_looping_over_recv = 1;
     s_user_params.do_warmup = true;
     s_user_params.pre_warmup_wait = 0;
-    s_user_params.is_vmarxfiltercb = false;
-    s_user_params.is_vmazcopyread = false;
+    s_user_params.is_rxfiltercb = false;
+    s_user_params.is_zcopyread = false;
     g_debug_level = LOG_LVL_INFO;
     s_user_params.mc_loop_disable = true;
     s_user_params.uc_reuseaddr = false;
@@ -2910,16 +2910,16 @@ int prepare_socket(int fd, struct fds_data *p_data)
 #ifdef ST_TEST
     if (!stTest)
 #endif
-        if (!rc && (s_user_params.is_vmarxfiltercb && g_vma_api)) {
+        if (!rc && (s_user_params.is_rxfiltercb && g_vma_api)) {
             // Try to register application with VMA's special receive notification callback logic
             if (g_vma_api->register_recv_callback(fd, myapp_vma_recv_pkt_filter_callback, NULL) <
                 0) {
                 log_err("vma_api->register_recv_callback failed. Try running without option "
-                        "'vmarxfiltercb'");
+                        "'rxfiltercb'/'vmarxfiltercb'");
             } else {
                 log_dbg("vma_api->register_recv_callback successful registered");
             }
-        } else if (!rc && (s_user_params.is_vmazcopyread && g_vma_api)) {
+        } else if (!rc && (s_user_params.is_zcopyread && g_vma_api)) {
             g_zeroCopyData[fd] = new ZeroCopyData();
             g_zeroCopyData[fd]->allocate();
         }
@@ -3336,7 +3336,7 @@ int bringup(const int *p_daemonize) {
     int _vma_pkts_desc_size = 0;
 
 #ifdef USING_VMA_EXTRA_API
-    if (!rc && (s_user_params.is_vmarxfiltercb || s_user_params.is_vmazcopyread ||
+    if (!rc && (s_user_params.is_rxfiltercb || s_user_params.is_zcopyread ||
                 s_user_params.fd_handler_type == SOCKETXTREME)) {
         // Get VMA extended API
         g_vma_api = vma_get_api();
@@ -3351,7 +3351,7 @@ int bringup(const int *p_daemonize) {
             sizeof(struct vma_packets_t) + sizeof(struct vma_packet_t) + sizeof(struct iovec) * 16;
     }
 #else
-    if (!rc && (s_user_params.is_vmarxfiltercb || s_user_params.is_vmazcopyread ||
+    if (!rc && (s_user_params.is_rxfiltercb || s_user_params.is_zcopyread ||
                 s_user_params.fd_handler_type == SOCKETXTREME)) {
         errno = EPERM;
         exit_with_err("Please compile with VMA Extra API to use these options", SOCKPERF_ERR_FATAL);
@@ -3631,8 +3631,8 @@ is_blocked = %d \n\t\
 is_nonblocked_send = %d \n\t\
 do_warmup = %d \n\t\
 pre_warmup_wait = %d \n\t\
-is_vmarxfiltercb = %d \n\t\
-is_vmazcopyread = %d \n\t\
+is_rxfiltercb = %d \n\t\
+is_zcopyread = %d \n\t\
 mc_loop_disable = %d \n\t\
 mc_ttl = %d \n\t\
 uc_reuseaddr = %d \n\t\
@@ -3660,8 +3660,8 @@ packet pace limit = %d",
             s_user_params.packetrate_stats_print_details, s_user_params.fd_handler_type,
             s_user_params.mthread_server, s_user_params.sock_buff_size, s_user_params.threads_num,
             s_user_params.threads_affinity, s_user_params.is_blocked, s_user_params.is_nonblocked_send,
-            s_user_params.do_warmup, s_user_params.pre_warmup_wait, s_user_params.is_vmarxfiltercb,
-            s_user_params.is_vmazcopyread, s_user_params.mc_loop_disable, s_user_params.mc_ttl,
+            s_user_params.do_warmup, s_user_params.pre_warmup_wait, s_user_params.is_rxfiltercb,
+            s_user_params.is_zcopyread, s_user_params.mc_loop_disable, s_user_params.mc_ttl,
             s_user_params.uc_reuseaddr, s_user_params.tcp_nodelay,
             s_user_params.client_work_with_srv_num, s_user_params.b_server_reply_via_uc,
             s_user_params.b_server_dont_reply, s_user_params.b_server_detect_gaps,

--- a/src/vma-xlio-redirect.h
+++ b/src/vma-xlio-redirect.h
@@ -26,8 +26,8 @@
  * OF SUCH DAMAGE.
  */
 
-#ifndef VMA_REDIRECT_H
-#define VMA_REDIRECT_H
+#ifndef VMA_XLIO_REDIRECT_H
+#define VMA_XLIO_REDIRECT_H
 
 #include <fcntl.h>
 #include <unistd.h>
@@ -50,44 +50,45 @@
 /**
  * Expected order of operations:
  * ==============================
- * 1. N x vma_setenv()
- * 2. vma_log_set_cb_func();
- * 3. vma_set_func_pointers();
+ * 1. N x vma_xlio_setenv()
+ * 2. vma_xlio_log_set_cb_func();
+ * 3. vma_xlio_try_set_func_pointers() or vma_xlio_set_func_pointers();
  *
  * all functions return 'true' on success; 'false' - otherwise
  *
  * NOTE: including this header will redirect all relevant API calls to pointers
  * to functions. Hence, you you are allowed to call any of the relevant APIs,
- * only after successfully completing vma_set_func_pointers()!
+ * only after successfully completing vma_xlio_try_set_func_pointers() or
+ * vma_xlio_set_func_pointers()!
  *
  */
 
 //------------------------------------------------------------------------------
-// The  vma_setenv()  function adds the variable 'name' to the environment with
+// The  vma_xlio_setenv()  function adds the variable 'name' to the environment with
 // the value 'value', only if 'name' does not already exist.  If 'name' does exist
 // in the environment, then the value of 'name' is not changed.
-static inline bool vma_setenv(const char *name, const char *value) {
+static inline bool vma_xlio_setenv(const char *name, const char *value) {
     return setenv(name, value, 0) == 0;
 }
 
 //
 //------------------------------------------------------------------------------
-// NOTE: int log_level is equivalent to VMA_TRACELEVEL (see VMA README.txt)
-typedef void (*vma_log_cb_t)(int log_level, const char *str);
+// NOTE: int log_level is equivalent to VMA_TRACELEVEL (see VMA README.txt) and
+// XLIO_TRACELEVEL (see XLIO README.txt)
+typedef void (*vma_xlio_log_cb_t)(int log_level, const char *str);
 //
-// NOTE: log_cb will run in context of vma; hence, it must not block the thread
-bool vma_log_set_cb_func(vma_log_cb_t log_cb);
-
-//
-//------------------------------------------------------------------------------
-// loads libvma.so only in case 'loadVma' is set.  In any case sets
-// global pointer variables for ALL vma related function pointers.
-bool vma_set_func_pointers(bool loadVma);
+// NOTE: log_cb will run in context of vma/xlio; hence, it must not block the thread
+bool vma_xlio_log_set_cb_func(vma_xlio_log_cb_t log_cb);
 
 //------------------------------------------------------------------------------
-// loads libvma according to the given 'loadVmaPath',  then set
-// global pointer variables for ALL vma related function pointers.
-bool vma_set_func_pointers(const char *LibVmaPath);
+// try to set global pointer variables for all VMA/XLIO related function
+// pointers.
+bool vma_xlio_try_set_func_pointers();
+
+//------------------------------------------------------------------------------
+// loads libvma/libxlio according to the given 'loadLibPath',  then set
+// global pointer variables for ALL vma/xlio related function pointers.
+bool vma_xlio_set_func_pointers(const char *loadLibPath);
 
 /**
  *-----------------------------------------------------------------------------
@@ -212,11 +213,11 @@ extern vfork_fptr_t fn_vfork;
 extern daemon_fptr_t fn_daemon;
 extern sigaction_fptr_t fn_sigaction;
 
-#ifndef VMA_NO_FUNCTIONS_DEFINES
+#ifndef VMA_XLIO_NO_FUNCTIONS_DEFINES
 // The following definitions will replace ALL relevant API calls with calls to our function
 // pointers.
 // NOTE: before any relevant API call, you MUST set our function pointers thru successful call to
-// 'vma_set_func_pointers'
+// 'vma_xlio_try_set_func_pointers' or 'vma_xlio_set_func_pointers'
 // (note: these definitions will not catch function prototypes neither combinations like 'struct
 // sigaction')
 #define socket(...) fn_socket(__VA_ARGS__)
@@ -272,6 +273,6 @@ extern sigaction_fptr_t fn_sigaction;
 #define daemon(...) fn_daemon(__VA_ARGS__)
 #define sigaction(...) fn_sigaction(__VA_ARGS__)
 
-#endif // VMA_NO_FUNCTIONS_DEFINES
+#endif // VMA_XLIO_NO_FUNCTIONS_DEFINES
 
-#endif // VMA_REDIRECT_H
+#endif // VMA_XLIO_REDIRECT_H


### PR DESCRIPTION
This solution allows to accelerate networking in sockperf using XLIO library via LD_PRELOAD or --load-xlio flag. XLIO extended API is not supported yet.

- Added flag `--load-xlio` to load XLIO library.
- Configuring XLIO logging in the same way as VMA logging is configured.
- Notify user that `--tls` and `--load-vma`/`--load-xlio` arguments aren't compatible.
- Added synonyms for vma-ext-api-related command-line keys (`--zcopyread` as a synonym for `--vmazcopyread`, `--rxfiltercb` for `--vmarxfiltercb`).
- Now we can specify alternative path to VMA library on configure step. Conceptually `--enable-vma-api` mimics the behavior of `--with-...` flag.