### PR TITLE
issue: 2935075 Fix Windows support

### DIFF
--- a/doc/main.dox
+++ b/doc/main.dox
@@ -110,7 +110,9 @@ sockperf: [tid 4805] using epoll() to block on socket(s)
    - address - Internet Protocol (IP) address or host name (IPv6 addresses must be enclosed in square brackets);
    - port - Port number;
    - mc_src_addr - Optional multicast source IP address or host name.
-   - PATH - absolute path for UNIX Domain Socket, the line must start with '/'
+   - PATH - absolute path for UNIX Domain Socket
+            Linux - line must start with '/'
+            Windows - line must start with absoulte path including directory, e.g 'c:\tmp\test'
 
 
 @subsection _option 3.1 Available options

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -204,7 +204,7 @@ void printHistogram(uint32_t binSize, std::map<uint32_t, uint32_t> &activeBins, 
     std::map<uint32_t, uint32_t>::iterator itr;
 
     // Scale to terminal
-#ifndef WIN32
+#ifndef __windows__
     struct winsize size;
     ioctl(STDOUT_FILENO, TIOCGWINSZ, &size);
     terminalWidth = size.ws_col;
@@ -824,7 +824,7 @@ static int _connect_check(int ifd) {
 
 #define POLL_TIMEOUT_MS 1
 
-#ifdef WIN32
+#ifdef __windows__
     fd_set rfds, wfds;
     struct timeval tv;
     tv.tv_sec = 0;
@@ -841,7 +841,7 @@ static int _connect_check(int ifd) {
     struct pollfd fds = { .fd = ifd, .events = POLLIN | POLLOUT, };
     pollrc = poll(&fds, 1, POLL_TIMEOUT_MS);
     avail = pollrc > 0 && (fds.revents & (POLLIN | POLLOUT));
-#endif /* WIN32 */
+#endif /* __windows__ */
 
     if (pollrc < 0) {
         log_err("Failed to poll for events during connection establishment");
@@ -884,11 +884,11 @@ int Client<IoType, SwitchDataIntegrity, SwitchActivityInfo, SwitchCycleDuration,
                 struct sockaddr_store_t unix_addr;
                 socklen_t unix_addr_len;
                 if (p_client_bind_addr->ss_family == AF_UNIX && g_pApp->m_const_params.sock_type == SOCK_DGRAM) { // Need to bind localy
-#ifdef WIN32
+#ifdef __windows__
                     log_err("AF_UNIX with DGRAM isn't supported in windows");
                     rc = SOCKPERF_ERR_SOCKET;
                     break;
-#else
+#else // __windows__
                     if (p_client_bind_addr->addr_un.sun_path[0] == 0) { // no specific addr client_info was provoided
                         std::string sun_path = build_client_socket_name(&s_user_params.addr.addr_un, getpid(), ifd);
                         log_dbg("No client name was provided, setting addr_un.sun_path to %s\n",
@@ -906,7 +906,7 @@ int Client<IoType, SwitchDataIntegrity, SwitchActivityInfo, SwitchCycleDuration,
                         p_client_bind_addr = &unix_addr;
                         client_bind_addr_len = unix_addr_len;
                     }
-#endif
+#endif //__windows__
                 }
 
                 log_dbg("[fd=%d] Binding to: %s...", ifd, hostport.c_str());
@@ -1258,7 +1258,7 @@ void client_handler(handler_info *p_info) {
             client_handler<IoRecvfromMUX>(p_info->fd_min, p_info->fd_max, p_info->fd_num);
             break;
         }
-#ifndef WIN32
+#ifndef __windows__
         case POLL: {
             client_handler<IoPoll>(p_info->fd_min, p_info->fd_max, p_info->fd_num);
             break;

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -64,7 +64,7 @@ std::string sockaddr_to_hostport(const struct sockaddr *addr)
     if (addr->sa_family == AF_INET6) {
         return "[" + std::string(hbuf) + "]:" + std::string(pbuf);
     } else if (addr->sa_family == AF_UNIX) {
-        return std::string(pbuf) + " [UNIX]";
+        return std::string(addr->sa_data);
     } else {
         return std::string(hbuf) + ":" + std::string(pbuf);
     }

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -231,7 +231,7 @@ void hexdump(void *ptr, int buflen) {
 const char *handler2str(fd_block_handler_t type) {
     // must be coordinated with fd_block_handler_t in defs.h
     static const char *s_fds_handle_desc[FD_HANDLE_MAX] = { "recvfrom", "recvfrom", "select"
-#ifndef WIN32
+#ifndef __windows__
                                                             ,
                                                             "poll", "epoll",
 #ifdef USING_VMA_EXTRA_API

--- a/src/common.h
+++ b/src/common.h
@@ -82,7 +82,7 @@ static inline int msg_sendto(int fd, uint8_t *buf, int nbytes,
  * the MSG_NOSIGNAL flag.
  * Note: another way is call signal (SIGPIPE,SIG_IGN);
  */
-#ifndef WIN32
+#ifndef __windows__
     flags = MSG_NOSIGNAL;
 
     /*
@@ -94,7 +94,7 @@ static inline int msg_sendto(int fd, uint8_t *buf, int nbytes,
     if (g_pApp->m_const_params.is_nonblocked_send) {
         flags |= MSG_DONTWAIT;
     }
-#endif
+#endif // __windows__
 
     int size = nbytes;
     if (g_fds_array[fd]->sock_type == SOCK_STREAM) {

--- a/src/defs.h
+++ b/src/defs.h
@@ -31,7 +31,7 @@
 
 #define __STDC_FORMAT_MACROS
 
-#ifdef WIN32
+#ifdef __windows__
 #include <WS2tcpip.h>
 #include <Winsock2.h>
 #include <unordered_map>
@@ -96,7 +96,7 @@ typedef unsigned short int sa_family_t;
 #include "playback.h"
 #include "ip_address.h"
 
-#if !defined(WIN32) && !defined(__FreeBSD__)
+#if !defined(__windows__) && !defined(__FreeBSD__)
 #include "vma-xlio-redirect.h"
 #ifdef USING_VMA_EXTRA_API
 #include <mellanox/vma_extra.h>
@@ -152,7 +152,7 @@ const uint32_t TEST_FIRST_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC = 50;
     ":(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[0-5]?[0-9]{1,4})"                   \
     "(:([a-zA-Z0-9\\.\\-]+|\\[([a-fA-F0-9.:]+)\\]))?[\r\n]"
 
-#ifdef WIN32
+#ifdef __windows__
 #define UNIX_DOMAIN_SOCKET_FORMAT_REG_EXP                                                          \
         "^[UuTt]:([A-Za-z]:[\\\\/].*)[\r\n]*"
 #define RESOLVE_ADDR_FORMAT_SOCKET                                                                 \
@@ -635,7 +635,7 @@ typedef enum { // must be coordinated with s_fds_handle_desc in common.cpp
     RECVFROM = 0,
     RECVFROMMUX,
     SELECT,
-#ifndef WIN32
+#ifndef __windows__
     POLL,
     EPOLL,
 #endif

--- a/src/input_handlers.h
+++ b/src/input_handlers.h
@@ -62,7 +62,7 @@ public:
     the MSG_NOSIGNAL flag.
     Note: another way is call signal (SIGPIPE,SIG_IGN);
  */
-#ifndef WIN32
+#ifndef __windows__
         flags = MSG_NOSIGNAL;
 #endif
 

--- a/src/iohandlers.cpp
+++ b/src/iohandlers.cpp
@@ -159,7 +159,7 @@ int IoSelect::prepareNetwork() {
 
     return rc;
 }
-#ifndef WIN32
+#ifndef __windows__
 //==============================================================================
 //------------------------------------------------------------------------------
 IoPoll::IoPoll(int _fd_min, int _fd_max, int _fd_num)

--- a/src/iohandlers.cpp
+++ b/src/iohandlers.cpp
@@ -38,7 +38,7 @@ static void print_addresses(const fds_data *data, int &list_count)
                 NI_NUMERICHOST | NI_NUMERICSERV);
         switch (data->server_addr.ss_family) {
             case AF_UNIX:
-                printf("[%2d] Address is %s # UDS type is %s\n", list_count++, pbuf, PRINT_SOCKET_TYPE(data->sock_type));
+                printf("[%2d] ADDR = %s # %s\n", list_count++, data->server_addr.addr_un.sun_path, PRINT_PROTOCOL(data->sock_type));
                 break;
             default:
                 printf("[%2d] IP = %-15s PORT = %5s # %s\n", list_count++, hbuf, pbuf, PRINT_PROTOCOL(data->sock_type));

--- a/src/iohandlers.h
+++ b/src/iohandlers.h
@@ -230,7 +230,7 @@ private:
     fd_set m_readfds, m_save_fds;
 };
 
-#ifndef WIN32
+#ifndef __windows__
 //==============================================================================
 class IoPoll : public IoHandler {
 public:

--- a/src/ip_address.cpp
+++ b/src/ip_address.cpp
@@ -29,9 +29,13 @@
 #include "ip_address.h"
 #include "common.h"
 
+#ifdef WIN32
+#include <ws2tcpip.h>
+#else
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <string.h>
+#endif
 
 IPAddress::IPAddress(const IPAddress &rhs) : m_family(rhs.m_family), m_addr6(rhs.m_addr6), m_addr_un(rhs.m_addr_un)
 {
@@ -100,7 +104,7 @@ bool IPAddress::resolve(const char *str, IPAddress &out, std::string &err)
             }
         }
     } else {
-        err = gai_strerror(res);
+        err = os_get_error(res);
     }
     freeaddrinfo(result);
 

--- a/src/ip_address.cpp
+++ b/src/ip_address.cpp
@@ -29,7 +29,7 @@
 #include "ip_address.h"
 #include "common.h"
 
-#ifdef WIN32
+#ifdef __windows__
 #include <ws2tcpip.h>
 #else
 #include <arpa/inet.h>

--- a/src/ip_address.h
+++ b/src/ip_address.h
@@ -29,10 +29,23 @@
 #ifndef IP_ADDRESS_H_
 #define IP_ADDRESS_H_
 
+#ifdef WIN32
+#include <WS2tcpip.h>
+#include <Winsock2.h>
+#include <unordered_map>
+#include <Winbase.h>
+#include <stdint.h>
+#include <afunix.h>
+typedef unsigned short int sa_family_t;
+
+#elif __linux__
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <sys/un.h>      /* definitions for UNIX domain sockets */
 
+#endif
+
+#include "os_abstract.h"
 #include <functional>
 #include <string>
 

--- a/src/ip_address.h
+++ b/src/ip_address.h
@@ -29,7 +29,7 @@
 #ifndef IP_ADDRESS_H_
 #define IP_ADDRESS_H_
 
-#ifdef WIN32
+#ifdef __windows__
 #include <WS2tcpip.h>
 #include <Winsock2.h>
 #include <unordered_map>

--- a/src/os_abstract.cpp
+++ b/src/os_abstract.cpp
@@ -26,10 +26,9 @@
  * OF SUCH DAMAGE.
  */
 
-#include "os_abstract.h"
-
-#include <string.h>
 #include <stdio.h>
+#include "os_abstract.h"
+#include <string.h>
 
 void os_printf_backtrace(void) {
 #ifdef WIN32
@@ -51,7 +50,7 @@ void os_printf_backtrace(void) {
     for (i = 0; i < frames; i++) {
         SymFromAddr(process, (DWORD64)(stack[i]), 0, symbol);
 
-        printf("%i: %s - 0x%0X\n", frames - i - 1, symbol->Name, symbol->Address);
+        printf("%i: %s - 0x%llu\n", frames - i - 1, symbol->Name, symbol->Address);
     }
 
     free(symbol);
@@ -265,6 +264,35 @@ int os_set_duration_timer(const itimerval &timer, sig_handler handler) {
     }
 #endif
     return 0;
+}
+
+void os_set_disarm_timer(const itimerval& timer) {
+#ifdef WIN32
+    if (SetTimer(NULL, 0, 0, NULL) == 0) {
+        printf("ERROR: SetTimer() failed when disarming");
+    }
+#else
+    if (setitimer(ITIMER_REAL, &timer, NULL)) {
+        printf("ERROR: setitimer() failed when disarming");
+    }
+#endif
+
+}
+
+const char* os_get_error(int res) {
+#ifdef WIN32
+    return gai_strerrorA(res);
+#else
+    return gai_strerror(res);
+#endif
+}
+
+void os_unlink_unix_path(char* path) {
+#ifdef WIN32
+    remove(path);
+#else
+    unlink(path);
+#endif
 }
 
 #ifdef WIN32

--- a/src/os_abstract.h
+++ b/src/os_abstract.h
@@ -48,6 +48,7 @@
 
 #ifdef WIN32
 
+#include <WS2tcpip.h>
 #include <Dbghelp.h> // backtrace
 #include <signal.h>
 #include <Winsock2.h>
@@ -105,6 +106,7 @@ void *win_set_timer(void *p_timer);
 #include <sys/resource.h>
 #include <fcntl.h>
 #include <netinet/in.h>
+#include <netdb.h>
 
 #define INVALID_SOCKET (-1)
 
@@ -194,9 +196,12 @@ void os_printf_backtrace(void);
 int os_set_nonblocking_socket(int fd);
 int os_daemonize();
 int os_set_duration_timer(const itimerval &timer, sig_handler handler);
+void os_set_disarm_timer(const itimerval& timer);
 int os_get_max_active_fds_num();
 bool os_sock_startup();
 bool os_sock_cleanup();
+const char* os_get_error(int res);
+void os_unlink_unix_path(char* path);
 
 // Colors
 #ifdef WIN32

--- a/src/os_abstract.h
+++ b/src/os_abstract.h
@@ -43,10 +43,10 @@
 #include "ticks_os.h"
 
 /***********************************************************************************
-*				 WIN32
+*				 __windows__
 ***********************************************************************************/
 
-#ifdef WIN32
+#ifdef __windows__
 
 #include <WS2tcpip.h>
 #include <Dbghelp.h> // backtrace
@@ -164,7 +164,7 @@ void *win_set_timer(void *p_timer);
 ***********************************************************************************/
 
 typedef struct os_thread_t {
-#ifdef WIN32
+#ifdef __windows__
     HANDLE hThread;
     DWORD tid;
 #else
@@ -173,7 +173,7 @@ typedef struct os_thread_t {
 } os_thread_t;
 
 typedef struct os_mutex_t {
-#ifndef WIN32
+#ifndef __windows__
     pthread_mutex_t mutex;
 #else
     HANDLE mutex;
@@ -181,7 +181,7 @@ typedef struct os_mutex_t {
 } os_mutex_t;
 
 typedef struct os_cpuset_t {
-#ifdef WIN32
+#ifdef __windows__
     DWORD_PTR cpuset;
 #elif __FreeBSD__
     cpuset_t cpuset;
@@ -204,7 +204,7 @@ const char* os_get_error(int res);
 void os_unlink_unix_path(char* path);
 
 // Colors
-#ifdef WIN32
+#ifdef __windows__
 #define MAGNETA ""
 #define RED ""
 #define ENDCOLOR ""
@@ -240,7 +240,7 @@ int os_set_affinity(const os_thread_t &thread, const os_cpuset_t &_mycpuset);
 // ERRORS
 
 inline bool os_err_in_progress() {
-#ifdef WIN32
+#ifdef __windows__
     // In Windows it's WSAEINPROGRESS for blocking sockets and WSAEWOULDBLOCK for non-vlocking
     // sockets
     return (WSAGetLastError() == WSAEWOULDBLOCK || WSAGetLastError() == WSAEINPROGRESS);
@@ -250,7 +250,7 @@ inline bool os_err_in_progress() {
 }
 
 inline bool os_err_eagain() {
-#ifdef WIN32
+#ifdef __windows__
     return (WSAGetLastError() == WSAEWOULDBLOCK);
 #else
     return (errno == EAGAIN);
@@ -258,14 +258,14 @@ inline bool os_err_eagain() {
 }
 
 inline bool os_err_conn_reset() {
-#ifdef WIN32
+#ifdef __windows__
     return (WSAGetLastError() == WSAECONNRESET);
 #else
     return (errno == ECONNRESET);
 #endif
 }
 
-#ifdef WIN32
+#ifdef __windows__
 #define _max(x, y) max(x, y)
 #define _min(x, y) min(x, y)
 #else

--- a/src/port_descriptor.h
+++ b/src/port_descriptor.h
@@ -31,7 +31,7 @@
 
 #include <stdint.h>
 
-#ifdef WIN32
+#ifdef __windows__
 
 typedef uint16_t in_port_t;
 
@@ -39,7 +39,7 @@ typedef uint16_t in_port_t;
 
 #include <netinet/in.h>  /* internet address manipulation */
 
-#endif // WIN32
+#endif // __windows__
 
 typedef struct port_descriptor {
     int sock_type; /**< SOCK_STREAM (tcp), SOCK_DGRAM (udp), SOCK_RAW (ip) */

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -411,7 +411,7 @@ void server_handler(handler_info *p_info) {
             server_handler<IoSelect>(p_info->fd_min, p_info->fd_max, p_info->fd_num);
             break;
         }
-#ifndef WIN32
+#ifndef __windows__
         case POLL: {
             server_handler<IoPoll>(p_info->fd_min, p_info->fd_max, p_info->fd_num);
             break;

--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -101,7 +101,7 @@
 #include <stdio.h>
 #include <sys/stat.h>
 
-#ifndef WIN32
+#ifndef __windows__
 #include <dlfcn.h>
 #endif
 
@@ -188,7 +188,7 @@ static const AOPT_DESC common_opt_desc[] = {
       AOPT_ARG,
       aopt_set_literal('F'),
       aopt_set_string("iomux-type"),
-#ifdef WIN32
+#ifdef __windows__
       "Type of multiple file descriptors handle [s|select|r|recvfrom](default select)."
 #elif __FreeBSD__
       "Type of multiple file descriptors handle [s|select|p|poll|r|recvfrom](default select)."
@@ -201,7 +201,7 @@ static const AOPT_DESC common_opt_desc[] = {
       AOPT_ARG,
       aopt_set_literal(0),
       aopt_set_string("timeout"),
-#ifdef WIN32
+#ifdef __windows__
       "Set select timeout to <msec>, -1 for infinite (default is 10 msec)."
 #elif __FreeBSD__
       "Set select/poll timeout to <msec>, -1 for infinite (default is 10 msec)."
@@ -266,7 +266,7 @@ static const AOPT_DESC common_opt_desc[] = {
     { OPT_PREWARMUPWAIT,                                        AOPT_ARG,
       aopt_set_literal(0),                                      aopt_set_string("pre-warmup-wait"),
       "Time to wait before sending warm up messages (seconds)." },
-#ifndef WIN32
+#ifndef __windows__
     { OPT_ZCOPYREAD,                                      AOPT_NOARG,
       aopt_set_literal(0),                                aopt_set_string("zcopyread", "vmazcopyread"),
       "Use VMA's zero copy reads API (See VMA's readme)." },
@@ -1518,7 +1518,7 @@ static int proc_mode_server(int id, int argc, const char **argv) {
           aopt_set_literal(0),
           aopt_set_string("cpu-affinity"),
           "Set threads affinity to the given core ids in list format (see: cat /proc/cpuinfo)." },
-#ifndef WIN32
+#ifndef __windows__
         { OPT_RXFILTERCB,
           AOPT_NOARG,
           aopt_set_literal(0),
@@ -1613,7 +1613,7 @@ static int proc_mode_server(int id, int argc, const char **argv) {
                 rc = SOCKPERF_ERR_BAD_ARGUMENT;
             }
         }
-#ifndef WIN32
+#ifndef __windows__
         if (!rc && aopt_check(server_obj, OPT_RXFILTERCB)) {
             s_user_params.is_rxfiltercb = true;
         }
@@ -1659,7 +1659,7 @@ static int proc_mode_server(int id, int argc, const char **argv) {
         printf(" " MODULE_NAME
                " %s [-i ip / --addr address] [-p port] [--mc-rx-if ip] [--mc-tx-if ip] [--mc-source-filter ip]\n",
                sockperf_modes[id].name);
-#ifndef WIN32
+#ifndef __windows__
         printf(" " MODULE_NAME
                " %s -f file [-F s/p/e] [--mc-rx-if ip] [--mc-tx-if ip] [--mc-source-filter ip]\n",
                sockperf_modes[id].name);
@@ -1815,7 +1815,7 @@ static int parse_common_opt(const AOPT_OBJECT *common_obj) {
                 if (optarg) {
                     strncpy(feedfile_name, optarg, MAX_ARGV_SIZE);
                     feedfile_name[MAX_PATH_LENGTH - 1] = '\0';
-#if defined(WIN32) || defined(__FreeBSD__)
+#if defined(__windows__) || defined(__FreeBSD__)
                     s_user_params.fd_handler_type = SELECT;
 #else
                     s_user_params.fd_handler_type = EPOLL;
@@ -1838,7 +1838,7 @@ static int parse_common_opt(const AOPT_OBJECT *common_obj) {
 
                     strncpy(fd_handle_type, optarg, MAX_ARGV_SIZE);
                     fd_handle_type[MAX_ARGV_SIZE - 1] = '\0';
-#ifndef WIN32
+#ifndef __windows__
 #ifndef __FreeBSD__
                     if (!strcmp(fd_handle_type, "epoll") || !strcmp(fd_handle_type, "e")) {
                         s_user_params.fd_handler_type = EPOLL;
@@ -1953,7 +1953,7 @@ static int parse_common_opt(const AOPT_OBJECT *common_obj) {
                 errno = 0;
                 int value = strtol(optarg, NULL, 0);
                 if (errno != 0 || value < -1) {
-#ifdef WIN32
+#ifdef __windows__
                     log_msg("'-%d' Invalid select timeout val: %s", OPT_SELECT_TIMEOUT, optarg);
 #elif __FreeBSD__
                     log_msg("'-%d' Invalid select/poll timeout val: %s", OPT_SELECT_TIMEOUT,
@@ -2004,7 +2004,7 @@ static int parse_common_opt(const AOPT_OBJECT *common_obj) {
         if (!rc && aopt_check(common_obj, OPT_TOS)) {
             const char *optarg = aopt_value(common_obj, OPT_TOS);
             if (optarg) {
-#if defined(WIN32) || defined(_WIN32)
+#if defined(__windows__) || defined(___windows__)
                 log_msg("TOS option not supported for Windows");
                 rc = SOCKPERF_ERR_UNSUPPORTED;
 #else
@@ -2017,7 +2017,7 @@ static int parse_common_opt(const AOPT_OBJECT *common_obj) {
         if (!rc && aopt_check(common_obj, OPT_LLS)) {
             const char *optarg = aopt_value(common_obj, OPT_LLS);
             if (optarg) {
-#if defined(WIN32) || defined(_WIN32)
+#if defined(__windows__) || defined(___windows__)
                 log_msg("LLS option not supported for Windows");
                 rc = SOCKPERF_ERR_UNSUPPORTED;
 #else
@@ -2093,7 +2093,7 @@ static int parse_common_opt(const AOPT_OBJECT *common_obj) {
         if (!rc && aopt_check(common_obj, OPT_SOCK_ACCL)) {
             s_user_params.withsock_accl = true;
         }
-#ifndef WIN32
+#ifndef __windows__
 
         if (!rc && aopt_check(common_obj, OPT_ZCOPYREAD)) {
             s_user_params.is_zcopyread = true;
@@ -2150,7 +2150,7 @@ static int parse_common_opt(const AOPT_OBJECT *common_obj) {
             }
         }
 #endif // !defined(__FreeBSD__)
-#endif // !defined(WIN32)
+#endif // !defined(__windows__)
 
         if (!rc && aopt_check(common_obj, OPT_TCP)) {
             if (!aopt_check(common_obj, 'f')) {
@@ -2365,13 +2365,13 @@ void cleanup() {
                 }
                 if (s_user_params.addr.ss_family == AF_UNIX) {
                     os_unlink_unix_path(s_user_params.client_bind_info.addr_un.sun_path);
-#ifndef WIN32 // AF_UNIX with DGRAM isn't supported in Win32
+#ifndef __windows__ // AF_UNIX with DGRAM isn't supported in __windows__
                     if (s_user_params.mode == MODE_CLIENT && s_user_params.sock_type == SOCK_DGRAM) { // unlink binded client
                         std::string sun_path = build_client_socket_name(&s_user_params.addr.addr_un, getpid(), ifd);
                         log_dbg("unlinking %s", sun_path.c_str());
                         unlink(sun_path.c_str());
                     }
-#endif
+#endif // __windows__
                     if (s_user_params.mode == MODE_SERVER)
                         os_unlink_unix_path(g_fds_array[ifd]->server_addr.addr_un.sun_path);
                 }
@@ -2431,14 +2431,14 @@ static void set_select_timeout(int time_out_msec) {
 
 //------------------------------------------------------------------------------
 void set_defaults() {
-#if !defined(WIN32) && !defined(__FreeBSD__)
+#if !defined(__windows__) && !defined(__FreeBSD__)
     bool success = vma_xlio_try_set_func_pointers();
     if (!success) {
         log_dbg("Failed to set function pointers for system functions.");
         log_dbg("Check vma-xlio-redirect.cpp for functions which your OS implementation is missing. "
                 "Re-compile sockperf without them.");
     }
-#elif defined WIN32
+#elif defined __windows__
     int rc = 0;
     if (os_sock_startup() == false) { // Only relevant for Windows
         log_err("Failed to initialize WSA");
@@ -2985,7 +2985,7 @@ static int set_sockets_from_feedfile(const char *feedfile_name) {
         log_msg("Can't open file: %s\n", feedfile_name);
         return SOCKPERF_ERR_NOT_EXIST;
     }
-#ifndef WIN32
+#ifndef __windows__
     if (!S_ISREG(st_buf.st_mode)) {
         log_msg("Can't open file: %s -not a regular file.\n", feedfile_name);
         return SOCKPERF_ERR_NOT_EXIST;

--- a/src/ticks.cpp
+++ b/src/ticks.cpp
@@ -28,10 +28,9 @@
 
 #define __STDC_LIMIT_MACROS // for INT64_MAX in __cplusplus
 
-#include "ticks.h"
-
-#include <string>
 #include <stdio.h>
+#include "ticks.h"
+#include <string>
 #include <errno.h>
 #include <string.h> // strerror()
 #include <stdint.h> // INT64_MAX

--- a/src/ticks.cpp
+++ b/src/ticks.cpp
@@ -37,7 +37,7 @@
 #include <math.h>
 
 #include "clock.h"
-#ifndef WIN32
+#ifndef __windows__
 #include <unistd.h> // for usleep
 #endif
 /**

--- a/src/ticks_os.h
+++ b/src/ticks_os.h
@@ -61,11 +61,6 @@ typedef int64_t ticks_t;
 #define usleep(x) Sleep(x / 1000)
 #define snprintf _snprintf
 
-struct timespec {
-    time_t tv_sec;    // Seconds.
-    long int tv_nsec; // Nanoseconds.
-};
-
 #endif
 
 /**

--- a/src/ticks_os.h
+++ b/src/ticks_os.h
@@ -48,7 +48,7 @@
 
 typedef int64_t ticks_t;
 
-#ifdef WIN32
+#ifdef __windows__
 
 #include <WinSock2.h>
 #include <Winbase.h>
@@ -75,7 +75,7 @@ inline ticks_t timespec2nsec(const struct timespec &_val) {
 }
 
 inline ticks_t os_gettimeoftsc() {
-#ifdef WIN32
+#ifdef __windows__
     LARGE_INTEGER lp;
     double PCFreq = 0.0;
     QueryPerformanceFrequency(&lp);
@@ -109,7 +109,7 @@ inline ticks_t os_gettimeoftsc() {
 }
 
 inline void os_ts_gettimeofclock(struct timespec *pts) {
-#ifdef WIN32
+#ifdef __windows__
     ticks_t val = os_gettimeoftsc(); // probably just NSEC_IN_SEC
     pts->tv_sec = val / NSEC_IN_SEC;
     pts->tv_nsec = val % NSEC_IN_SEC;

--- a/win/project/sockperf.vcxproj
+++ b/win/project/sockperf.vcxproj
@@ -28,26 +28,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v110</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -146,32 +146,34 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\aopt.cpp" />
-    <ClCompile Include="..\..\src\Client.cpp" />
+    <ClCompile Include="..\..\src\client.cpp" />
     <ClCompile Include="..\..\src\common.cpp" />
-    <ClCompile Include="..\..\src\Defs.cpp" />
+    <ClCompile Include="..\..\src\defs.cpp" />
     <ClCompile Include="..\..\src\IoHandlers.cpp" />
-    <ClCompile Include="..\..\src\Message.cpp" />
+    <ClCompile Include="..\..\src\ip_address.cpp" />
+    <ClCompile Include="..\..\src\message.cpp" />
     <ClCompile Include="..\..\src\os_abstract.cpp" />
-    <ClCompile Include="..\..\src\PacketTimes.cpp" />
-    <ClCompile Include="..\..\src\Playback.cpp" />
-    <ClCompile Include="..\..\src\Server.cpp" />
-    <ClCompile Include="..\..\src\SockPerf.cpp" />
-    <ClCompile Include="..\..\src\Ticks.cpp" />
+    <ClCompile Include="..\..\src\packet.cpp" />
+    <ClCompile Include="..\..\src\playback.cpp" />
+    <ClCompile Include="..\..\src\server.cpp" />
+    <ClCompile Include="..\..\src\sockperf.cpp" />
+    <ClCompile Include="..\..\src\ticks.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\aopt.h" />
-    <ClInclude Include="..\..\src\Client.h" />
+    <ClInclude Include="..\..\src\client.h" />
     <ClInclude Include="..\..\src\clock.h" />
     <ClInclude Include="..\..\src\common.h" />
-    <ClInclude Include="..\..\src\Defs.h" />
+    <ClInclude Include="..\..\src\defs.h" />
+    <ClInclude Include="..\..\src\input_handlers.h" />
     <ClInclude Include="..\..\src\IoHandlers.h" />
-    <ClInclude Include="..\..\src\Message.h" />
+    <ClInclude Include="..\..\src\ip_address.h" />
+    <ClInclude Include="..\..\src\message.h" />
     <ClInclude Include="..\..\src\os_abstract.h" />
-    <ClInclude Include="..\..\src\PacketTimes.h" />
-    <ClInclude Include="..\..\src\Playback.h" />
-    <ClInclude Include="..\..\src\Server.h" />
-    <ClInclude Include="..\..\src\Switches.h" />
-    <ClInclude Include="..\..\src\Ticks.h" />
+    <ClInclude Include="..\..\src\playback.h" />
+    <ClInclude Include="..\..\src\server.h" />
+    <ClInclude Include="..\..\src\switches.h" />
+    <ClInclude Include="..\..\src\ticks.h" />
     <ClInclude Include="..\..\src\ticks_os.h" />
   </ItemGroup>
   <ItemGroup>

--- a/win/project/sockperf.vcxproj
+++ b/win/project/sockperf.vcxproj
@@ -85,7 +85,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>__windows__;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -99,7 +99,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>__windows__;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -115,7 +115,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>__windows__;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -133,7 +133,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>__windows__;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>


### PR DESCRIPTION
Adding Windows support for sockperf including AF_UNIX. 
Most of the code is added with #ifdef WIN32, so no impact is expected on linux.

Major changes include:

1. AF_UNIX which in windows is only supported by SOCK_STREAM mode so no binding is needed from client side (thus no path_pid_num binding as provided in linux) 
2. Using new API s.a 'WSAStartup', 'DeleteFileA' (instead of unlink), 'closesocket()' instead of close(), etc.. 
3. Working with <winsock2.h> 

More about AF_UNIX in windows: 
https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/