### PR TITLE
issue: 3075439 Support for VMA and XLIO extra API in the same binary

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -91,12 +91,6 @@ AS_IF([test "${have_vma_api}" != "no"],
         have_vma_api=/usr
     fi
     CPPFLAGS="$CPPFLAGS -I$have_vma_api/include"
-    if test -d "$have_vma_api/lib64"
-    then
-        LDFLAGS="$LDFLAGS -L$have_vma_api/lib64"
-    else
-        LDFLAGS="$LDFLAGS -L$have_vma_api/lib"
-    fi
 
     AC_CHECK_HEADER([mellanox/vma_extra.h],
         [AC_DEFINE([USING_VMA_EXTRA_API],[1],[[Enable using VMA extra API]])],
@@ -105,6 +99,31 @@ AS_IF([test "${have_vma_api}" != "no"],
 AC_MSG_CHECKING(
     [for vma extra api])
 AC_MSG_RESULT([${have_vma_api}])
+
+##########################################################################
+# check XLIO extra API
+#
+AC_ARG_ENABLE(
+    [xlio-api],
+    AC_HELP_STRING([--enable-xlio-api],
+                   [SOCKPERF: enable xlio extra api support: 'yes', 'no' or library installation path (default=no)]),
+    [have_xlio_api=$enableval],
+    [have_xlio_api=no])
+AS_IF([test "${have_xlio_api}" != "no"],
+    [
+    if test "$have_xlio_api" = "yes"
+    then
+        have_xlio_api=/usr
+    fi
+    CPPFLAGS="$CPPFLAGS -I$have_xlio_api/include"
+
+    AC_CHECK_HEADER([mellanox/xlio_extra.h],
+        [AC_DEFINE([USING_XLIO_EXTRA_API],[1],[[Enable using XLIO extra API]])],
+        [AC_MSG_ERROR([xlio_extra.h file not found at $have_xlio_api/include])]
+        [have_xlio_api=no])])
+AC_MSG_CHECKING(
+    [for xlio extra api])
+AC_MSG_RESULT([${have_xlio_api}])
 
 ##########################
 # Documentation
@@ -214,5 +233,6 @@ AC_MSG_RESULT([
 	test:		${have_test}
 	tool:		${have_tool}
 	vma_api:	${have_vma_api}
+	xlio_api:	${have_xlio_api}
 	debug:		${have_debug}
 ])

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -793,7 +793,7 @@ void Client<IoType, SwitchDataIntegrity, SwitchActivityInfo, SwitchCycleDuration
 }
 
 //------------------------------------------------------------------------------
-#ifdef USING_VMA_EXTRA_API
+#ifdef USING_VMA_EXTRA_API // For VMA socketxtreme Only
 static int _connect_check_vma(int ifd) {
     int rc = SOCKPERF_ERR_SOCKET;
     int ring_fd = 0;
@@ -814,7 +814,7 @@ static int _connect_check_vma(int ifd) {
     }
     return rc;
 }
-#endif
+#endif // USING_VMA_EXTRA_API
 
 //------------------------------------------------------------------------------
 static int _connect_check(int ifd) {
@@ -886,12 +886,12 @@ int Client<IoType, SwitchDataIntegrity, SwitchActivityInfo, SwitchCycleDuration,
                         std::string sun_path = build_client_socket_name(&s_user_params.addr.addr_un, getpid(), ifd);
                         log_dbg("No client name was provided, setting addr_un.sun_path to %s\n",
                                sun_path.c_str());
-                        if (sun_path.length() > MAX_UDS_NAME) {
-                            log_err("length of client socket name (%s) is more than %d bytes", sun_path.c_str(), MAX_UDS_NAME);
+                        if (sun_path.length() >= sizeof(unix_addr.addr_un.sun_path)) {
+                            log_err("length of client socket name (%s) is greater-equal %zu bytes", sun_path.c_str(), sizeof(unix_addr.addr_un.sun_path));
                             rc = SOCKPERF_ERR_SOCKET;
                         } else {
                             memset(unix_addr.addr_un.sun_path, 0, sizeof(unix_addr.addr_un.sun_path));
-                            strncpy(unix_addr.addr_un.sun_path, sun_path.c_str(), MAX_UDS_NAME);
+                            memcpy(unix_addr.addr_un.sun_path, sun_path.c_str(), sun_path.length());
                             unix_addr_len = sizeof(struct sockaddr_un);
                             unix_addr.ss_family = AF_UNIX;
                             hostport = sun_path;
@@ -914,11 +914,11 @@ int Client<IoType, SwitchDataIntegrity, SwitchActivityInfo, SwitchCycleDuration,
                 if (connect(ifd, reinterpret_cast<const sockaddr *>(&(data->server_addr)),
                             data->server_addr_len) < 0) {
                     if (os_err_in_progress()) {
-#ifdef USING_VMA_EXTRA_API
+#ifdef USING_VMA_EXTRA_API // For VMA socketxtreme Only
                         if (g_pApp->m_const_params.fd_handler_type == SOCKETXTREME && g_vma_api) {
                             rc = _connect_check_vma(ifd);
                         } else
-#endif
+#endif // USING_VMA_EXTRA_API
                         {
                             rc = _connect_check(ifd);
                         }
@@ -1261,14 +1261,14 @@ void client_handler(handler_info *p_info) {
             client_handler<IoEpoll>(p_info->fd_min, p_info->fd_max, p_info->fd_num);
             break;
         }
-#endif
-#ifdef USING_VMA_EXTRA_API
+#endif // !__FreeBSD__
+#ifdef USING_VMA_EXTRA_API // For VMA socketxtreme Only
         case SOCKETXTREME: {
             client_handler<IoSocketxtreme>(p_info->fd_min, p_info->fd_max, p_info->fd_num);
             break;
         }
-#endif
-#endif
+#endif // USING_VMA_EXTRA_API
+#endif // !WIN32
         default: {
             ERROR_MSG("unknown file handler");
             break;

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -234,10 +234,10 @@ const char *handler2str(fd_block_handler_t type) {
 #ifndef WIN32
                                                             ,
                                                             "poll", "epoll",
-#ifdef USING_VMA_EXTRA_API
+#ifdef USING_VMA_EXTRA_API // For VMA socketxtreme Only
                                                             "socketxtreme"
-#endif
-#endif
+#endif // USING_VMA_EXTRA_API
+#endif // !WIN32
     };
 
     return s_fds_handle_desc[type];

--- a/src/defs.cpp
+++ b/src/defs.cpp
@@ -41,9 +41,11 @@ TicksTime g_cycleStartTime;
 
 debug_level_t g_debug_level = LOG_LVL_INFO;
 
-#ifdef USING_VMA_EXTRA_API
+#if defined(USING_VMA_EXTRA_API) || defined (USING_XLIO_EXTRA_API)
+#ifdef USING_VMA_EXTRA_API // VMA
 struct vma_buff_t *g_vma_buff = NULL;
 struct vma_completion_t *g_vma_comps;
+#endif // USING_VMA_EXTRA_API
 
 ZeroCopyData::ZeroCopyData() : m_pkt_buf(NULL), m_pkts(NULL) {}
 
@@ -54,7 +56,7 @@ ZeroCopyData::~ZeroCopyData() {
 }
 
 zeroCopyMap g_zeroCopyData;
-#endif
+#endif // USING_VMA_EXTRA_API || USING_XLIO_EXTRA_API
 
 uint32_t MPS_MAX = MPS_MAX_UL; // will be overwrite at runtime in case of ping-pong test
 PacketTimes *g_pPacketTimes = NULL;
@@ -66,8 +68,16 @@ fds_data **g_fds_array = NULL;
 int MAX_PAYLOAD_SIZE = 65507;
 int IGMP_MAX_MEMBERSHIPS = IP_MAX_MEMBERSHIPS;
 
-#ifdef USING_VMA_EXTRA_API
+#ifdef USING_VMA_EXTRA_API // VMA
 struct vma_api_t *g_vma_api;
-#endif
+#else
+void *g_vma_api = nullptr; // Dummy variable
+#endif // USING_VMA_EXTRA_API
+
+#ifdef USING_XLIO_EXTRA_API // XLIO
+struct xlio_api_t *g_xlio_api;
+#else
+void *g_xlio_api = nullptr; // Dummy variable
+#endif // USING_XLIO_EXTRA_API
 
 const App *g_pApp = NULL;

--- a/src/input_handlers.h
+++ b/src/input_handlers.h
@@ -119,68 +119,28 @@ public:
     }
 };
 
-#ifdef USING_VMA_EXTRA_API
-class SocketXtremeInputHandler : public MessageParser<BufferAccumulation> {
-private:
-    SocketRecvData &m_recv_data;
-    vma_buff_t *m_vma_buff;
-public:
-    inline SocketXtremeInputHandler(Message *msg, SocketRecvData &recv_data):
-        MessageParser<BufferAccumulation>(msg),
-        m_recv_data(recv_data),
-        m_vma_buff(NULL)
-    {}
+#if defined(USING_VMA_EXTRA_API) || defined(USING_XLIO_EXTRA_API)
+typedef int(* recvfrom_zcopy_func_t)(int __fd, void *__buf, size_t __nbytes, int *__flags,
+                                     struct sockaddr *__from, socklen_t *__fromlen);
 
-    /** Receive pending data from a socket
-     * @param [in] socket descriptor
-     * @param [out] recvfrom_addr address to save peer address into
-     * @param [inout] in - storage size, out - actual address size
-     * @return status code
-     */
-    inline int receive_pending_data(int fd, struct sockaddr *recvfrom_addr, socklen_t &size)
-    {
-        //TODO: update after IPv6 will be supported in libvma
-        size = sizeof(sockaddr_in);
-        std::memcpy(recvfrom_addr, &g_vma_comps->src, size);
-        m_vma_buff = g_vma_buff;
-        if (likely(m_vma_buff)) {
-            return m_vma_buff->len;
-        } else {
-            return 0;
-        }
-    }
-
-    template <class Callback>
-    inline bool iterate_over_buffers(Callback &callback)
-    {
-        for (vma_buff_t *cur = m_vma_buff; cur; cur = cur->next) {
-            bool res = process_buffer(callback, m_recv_data, (uint8_t *)cur->payload, cur->len);
-            if (unlikely(!res)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    inline void cleanup()
-    {
-    }
-};
-
-class VmaZCopyReadInputHandler : public MessageParser<BufferAccumulation> {
-private:
+template <typename PacketDataType, typename PacketsDataType, int MsgZCopyFlag>
+class ZCopyReadInputHandler : public MessageParser<BufferAccumulation> {
+protected:
     SocketRecvData &m_recv_data;
     int m_fd;
     ZeroCopyData *m_ptr;
     int m_non_zcopy_len;
+    recvfrom_zcopy_func_t recvfrom_zcopy;
 
 public:
-    inline VmaZCopyReadInputHandler(Message *msg, SocketRecvData &recv_data):
+    inline ZCopyReadInputHandler(Message *msg, SocketRecvData &recv_data,
+                                 recvfrom_zcopy_func_t recvfrom_zcopy_func):
         MessageParser<BufferAccumulation>(msg),
         m_recv_data(recv_data),
         m_fd(0),
         m_ptr(NULL),
-        m_non_zcopy_len(0)
+        m_non_zcopy_len(0),
+        recvfrom_zcopy(recvfrom_zcopy_func)
     {}
 
     /** Receive pending data from a socket
@@ -201,20 +161,20 @@ public:
             return 0;
         }
         // Receive the next packet with zero copy API
-        ret = g_vma_api->recvfrom_zcopy(fd, m_ptr->m_pkt_buf, Message::getMaxSize(), &flags,
-                                        (struct sockaddr *)recvfrom_addr, &size);
+        ret = recvfrom_zcopy(fd, m_ptr->m_pkt_buf, Message::getMaxSize(), &flags,
+                             (struct sockaddr *)recvfrom_addr, &size);
 
         if (likely(ret > 0)) {
-            if (flags & MSG_VMA_ZCOPY) {
+            if (flags & MsgZCopyFlag) {
                 // Zcopy receive is performed
-                m_ptr->m_pkts = (struct vma_packets_t *)m_ptr->m_pkt_buf;
+                m_ptr->m_pkts = m_ptr->m_pkt_buf;
                 m_non_zcopy_len = 0;
                 // Note: function return value is not equal to number of bytes
                 // received. This is not a problem because caller only checks
                 // that retval > 0 to continue processing.
             } else {
                 // zero-copy not performed so using buffer as a plain old data buffer
-                m_ptr->m_pkts = NULL;
+                m_ptr->m_pkts = nullptr;
                 m_non_zcopy_len = ret;
             }
         }
@@ -243,13 +203,15 @@ public:
         assert(m_ptr && "zero-copy data pointer must be initialized");
         if (likely(m_ptr->m_pkts)) {
             // iterate over zerocopy buffers
-            uint8_t *cur_ptr = (uint8_t *)&m_ptr->m_pkts->pkts[0];
-            for (size_t p = 0; p < m_ptr->m_pkts->n_packet_num; ++p) {
-                vma_packet_t *pkt = (vma_packet_t *)cur_ptr;
-                cur_ptr += offsetof(vma_packet_t, iov);
+            PacketsDataType *pkts = reinterpret_cast<PacketsDataType *>(m_ptr->m_pkts);
+            uint8_t *cur_ptr = reinterpret_cast<uint8_t *>(&pkts->pkts[0]);
+            for (size_t p = 0; p < pkts->n_packet_num; ++p) {
+                PacketDataType *pkt = reinterpret_cast<PacketDataType *>(cur_ptr);
+                cur_ptr += offsetof(PacketDataType, iov);
                 for (size_t i = 0; i < pkt->sz_iov; ++i) {
-                    bool ok = process_buffer(callback, m_recv_data, (uint8_t *)pkt->iov[i].iov_base,
-                        (int)pkt->iov[i].iov_len);
+                    bool ok = process_buffer(callback, m_recv_data,
+                                             reinterpret_cast<uint8_t *>(pkt->iov[i].iov_base),
+                                             static_cast<int>(pkt->iov[i].iov_len));
                     if (unlikely(!ok)) {
                         return false;
                     }
@@ -263,15 +225,92 @@ public:
             return process_buffer(callback, m_recv_data, m_ptr->m_pkt_buf, m_non_zcopy_len);
         }
     }
+};
+
+#ifdef USING_VMA_EXTRA_API // VMA
+class SocketXtremeInputHandler : public MessageParser<BufferAccumulation> {
+private:
+    SocketRecvData &m_recv_data;
+    vma_buff_t *m_vma_buff;
+public:
+    inline SocketXtremeInputHandler(Message *msg, SocketRecvData &recv_data):
+        MessageParser<BufferAccumulation>(msg),
+        m_recv_data(recv_data),
+        m_vma_buff(NULL)
+    {}
+
+    /** Receive pending data from a socket
+     * @param [in] socket descriptor
+     * @param [out] recvfrom_addr address to save peer address into
+     * @param [inout] in - storage size, out - actual address size
+     * @return status code
+     */
+    inline int receive_pending_data(int fd, struct sockaddr *recvfrom_addr, socklen_t &size)
+    {
+        size = sizeof(sockaddr_in);
+        std::memcpy(recvfrom_addr, &g_vma_comps->src, size);
+        m_vma_buff = g_vma_buff;
+        if (likely(m_vma_buff)) {
+            return m_vma_buff->len;
+        } else {
+            return 0;
+        }
+    }
+
+    template <class Callback>
+    inline bool iterate_over_buffers(Callback &callback)
+    {
+        for (vma_buff_t *cur = m_vma_buff; cur; cur = cur->next) {
+            bool res = process_buffer(callback, m_recv_data, (uint8_t *)cur->payload, cur->len);
+            if (unlikely(!res)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    inline void cleanup()
+    {
+    }
+};
+
+class VmaZCopyReadInputHandler : public ZCopyReadInputHandler<vma_packet_t, vma_packets_t, MSG_VMA_ZCOPY> {
+public:
+    inline VmaZCopyReadInputHandler(Message *msg, SocketRecvData &recv_data):
+        ZCopyReadInputHandler<vma_packet_t, vma_packets_t, MSG_VMA_ZCOPY>(msg, recv_data, g_vma_api->recvfrom_zcopy)
+    {}
 
     inline void cleanup()
     {
         if (likely(m_ptr && m_ptr->m_pkts)) {
-            g_vma_api->free_packets(m_fd, m_ptr->m_pkts->pkts, m_ptr->m_pkts->n_packet_num);
-            m_ptr->m_pkts = NULL;
+            vma_packets_t* vma_pkts = reinterpret_cast<vma_packets_t *>(m_ptr->m_pkts);
+            g_vma_api->free_packets(m_fd, vma_pkts->pkts, vma_pkts->n_packet_num);
+            m_ptr->m_pkts = nullptr;
         }
     }
 };
 #endif // USING_VMA_EXTRA_API
+
+#ifdef USING_XLIO_EXTRA_API // XLIO extra-api Only
+class XlioZCopyReadInputHandler :
+    public ZCopyReadInputHandler<xlio_recvfrom_zcopy_packet_t, xlio_recvfrom_zcopy_packets_t, MSG_XLIO_ZCOPY> {
+public:
+    inline XlioZCopyReadInputHandler(Message *msg, SocketRecvData &recv_data):
+        ZCopyReadInputHandler<xlio_recvfrom_zcopy_packet_t, xlio_recvfrom_zcopy_packets_t, MSG_XLIO_ZCOPY>(
+            msg, recv_data, g_xlio_api->recvfrom_zcopy)
+    {}
+
+    inline void cleanup()
+    {
+        if (likely(m_ptr && m_ptr->m_pkts)) {
+            xlio_recvfrom_zcopy_packets_t *xlio_pkts = reinterpret_cast<xlio_recvfrom_zcopy_packets_t *>(m_ptr->m_pkts);
+            g_xlio_api->recvfrom_zcopy_free_packets(m_fd, xlio_pkts->pkts, xlio_pkts->n_packet_num);
+            m_ptr->m_pkts = nullptr;
+        }
+    }
+};
+#endif // USING_XLIO_EXTRA_API
+
+#endif // USING_VMA_EXTRA_API || USING_XLIO_EXTRA_API
 
 #endif // INPUT_HANDLERS_H_

--- a/src/iohandlers.cpp
+++ b/src/iohandlers.cpp
@@ -251,7 +251,7 @@ int IoEpoll::prepareNetwork() {
     return rc;
 }
 #endif
-#ifdef USING_VMA_EXTRA_API
+#ifdef USING_VMA_EXTRA_API // VMA socketxtreme-extra-api Only
 //==============================================================================
 //------------------------------------------------------------------------------
 IoSocketxtreme::IoSocketxtreme(int _fd_min, int _fd_max, int _fd_num)
@@ -307,5 +307,5 @@ int IoSocketxtreme::prepareNetwork() {
     }
     return rc;
 }
-#endif
-#endif
+#endif // USING_VMA_EXTRA_API
+#endif // !WIN32

--- a/src/iohandlers.h
+++ b/src/iohandlers.h
@@ -379,7 +379,7 @@ private:
 };
 #endif
 
-#ifdef USING_VMA_EXTRA_API
+#ifdef USING_VMA_EXTRA_API // VMA socketxtreme-extra-api Only
 //==============================================================================
 class IoSocketxtreme : public IoHandler {
 public:
@@ -493,6 +493,6 @@ private:
     rings_vma_comps_map m_rings_vma_comps_map;
     rings_vma_comps_map::iterator m_rings_vma_comps_map_itr;
 };
-#endif
-#endif
-#endif /* IOHANDLERS_H_ */
+#endif // USING_VMA_EXTRA_API
+#endif // !WIN32
+#endif // IOHANDLERS_H_

--- a/src/ip_address.h
+++ b/src/ip_address.h
@@ -38,8 +38,6 @@
 
 #include <unordered_map>
 
-#define MAX_UDS_NAME 108
-
 class IPAddress {
 private:
     sa_family_t m_family;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -72,9 +72,9 @@ int ServerBase::initBeforeLoop() {
         for (int ifd = m_ioHandlerRef.m_fd_min; ifd <= m_ioHandlerRef.m_fd_max; ifd++) {
 
             if (!(g_fds_array[ifd] && (g_fds_array[ifd]->active_fd_list))) continue;
-#ifdef USING_VMA_EXTRA_API
+#ifdef USING_VMA_EXTRA_API // VMA callback-extra-api Only
             g_fds_array[ifd]->p_msg = m_pMsgReply;
-#endif
+#endif // USING_VMA_EXTRA_API
             const sockaddr_store_t *p_bind_addr = &g_fds_array[ifd]->server_addr;
             socklen_t bind_addr_len = g_fds_array[ifd]->server_addr_len;
 
@@ -273,11 +273,11 @@ int Server<IoType, SwitchActivityInfo, SwitchCalcGaps>::server_accept(int ifd) {
         tmp->recv.cur_offset = 0;
         tmp->recv.cur_size = tmp->recv.max_size;
 
-#ifdef USING_VMA_EXTRA_API
+#ifdef USING_VMA_EXTRA_API // VMA socketxtreme-extra-api Only
         if (g_vma_api && g_pApp->m_const_params.fd_handler_type == SOCKETXTREME) {
             active_ifd = g_vma_comps->user_data;
         } else
-#endif
+#endif // USING_VMA_EXTRA_API
         {
             active_ifd = (int)accept(
                 ifd, (struct sockaddr *)&addr,
@@ -311,14 +311,14 @@ int Server<IoType, SwitchActivityInfo, SwitchCalcGaps>::server_accept(int ifd) {
                             active_fd_list[i] = active_ifd;
                             g_fds_array[ifd]->active_fd_count++;
                             g_fds_array[active_ifd] = tmp.release();
-#ifdef USING_VMA_EXTRA_API
+#ifdef USING_VMA_EXTRA_API // VMA socketxtreme-extra-api Only
                             if (g_vma_api &&
                                 g_pApp->m_const_params.fd_handler_type == SOCKETXTREME) {
                                 std::string hostport = sockaddr_to_hostport(g_vma_comps->src);
                                 log_dbg("peer address to accept: %s [%d]",
                                         hostport.c_str(), active_ifd);
                             } else
-#endif
+#endif // USING_VMA_EXTRA_API
                             {
                                 std::string hostport = sockaddr_to_hostport(addr);
                                 log_dbg("peer address to accept: %s [%d]",
@@ -352,13 +352,13 @@ int Server<IoType, SwitchActivityInfo, SwitchCalcGaps>::server_accept(int ifd) {
                 if (tmp->active_fd_list) {
                     FREE(tmp->active_fd_list);
                 }
-#ifdef USING_VMA_EXTRA_API
+#ifdef USING_VMA_EXTRA_API // VMA socketxtreme-extra-api Only
                 if (g_vma_api && g_pApp->m_const_params.fd_handler_type == SOCKETXTREME) {
                     std::string hostport = sockaddr_to_hostport(g_vma_comps->src);
                     log_dbg("peer address to refuse: %s [%d]",
                             hostport.c_str(), active_ifd);
                 } else
-#endif
+#endif // USING_VMA_EXTRA_API
                 {
                     std::string hostport = sockaddr_to_hostport(addr);
                     log_dbg("peer address to refuse: %s [%d]", hostport.c_str(),
@@ -422,12 +422,12 @@ void server_handler(handler_info *p_info) {
             break;
         }
 #endif
-#ifdef USING_VMA_EXTRA_API
+#ifdef USING_VMA_EXTRA_API // VMA socketxtreme-extra-api Only
         case SOCKETXTREME: {
             server_handler<IoSocketxtreme>(p_info->fd_min, p_info->fd_max, p_info->fd_num);
             break;
         }
-#endif
+#endif // USING_VMA_EXTRA_API
 #endif
         default:
             ERROR_MSG("unknown file handler");


### PR DESCRIPTION
All VMA extra APIs are supported.
Only zcopyread is supported for XLIO.
It is possible to build sockperf with both --enable-vma-api and --enable-xlio-api.
Only one type of API can be used at runtime.

Signed-off-by: Alexander Grissik <agrissik@nvidia.com>