### PR TITLE
Adding tests for Unix Domain Socket

### DIFF
--- a/tests/verifier/lib/TE/Funclet.pm
+++ b/tests/verifier/lib/TE/Funclet.pm
@@ -262,7 +262,9 @@ sub execute
         # Execute script
         # which means $cmd will 'pipe' its output to SHELL. That means SHELL can be used 
         # to read the output of the command (specifically the stuff the command sends to STDOUT).
-        if ($$TARGET =~ m/:/) {
+        if ($$TARGET =~ m/^\//) {
+        # invoke command locally for UNIX sockets
+        } elsif ($$TARGET =~ m/:/) {
             # tell ssh to use IPv6 address
             $cmd = "ssh -6 $$TARGET " . $cmd;
         } else {

--- a/tests/verifier/lib/TE/Utility.pm
+++ b/tests/verifier/lib/TE/Utility.pm
@@ -387,7 +387,10 @@ sub te_create_feed_file
         } else {
             $line .= 'U:'
         }
-        if ($opt_addr !~ m/:/) {
+        if ($opt_addr =~ m/^\//) {
+            $line .= "$opt_addr";
+            $line .= "_$port\n";
+        } elsif ($opt_addr !~ m/:/) {
             $line .= "$group1";
             $line .= ".$group2";
             if ($group1 == 224 && $group4 > 254)

--- a/tests/verifier/lib/UDS.pm
+++ b/tests/verifier/lib/UDS.pm
@@ -1,0 +1,321 @@
+##
+# @file UDS.pm
+#
+# @brief Test Suite Unix Domain Socket.
+#
+#
+
+## @class
+# Container for common data.
+package UDS;
+
+use strict;
+use warnings;
+
+
+# Own modules
+use TE::Common;
+use TE::Funclet;
+use TE::Utility;
+
+
+our $test_suite_uds = 
+    [
+        {
+            name => 'tc1',
+            note => '#1 - ping-pong w/o arguments (default is udp)',
+            pre_proc => \&te_def_pre_proc,
+            server_proc => \&te_def_server_proc,
+            server_arg => 'sr -i TARGET() ',
+            client_proc => \&te_def_client_proc,
+            client_arg => 'pp -i TARGET() ',
+            result_proc => \&te_def_result_proc,
+            result_arg => {
+                server => {
+                    success => ['Test end', 'interrupted by', 'exit', 'ADDR'],
+                    failure => ['Segmentation fault', 'Assertion', 'ERROR']
+                },
+                client => {
+                    success => ['Test ended', 'Summary: Latency is', 'Warmup stage \(sending a few dummy messages\)...', 'ADDR'],
+                    failure => ['Segmentation fault', 'Assertion', 'ERROR', 'server down']
+                },
+            },
+            post_proc => \&te_def_post_proc,
+        },
+        {
+            name => 'tc2',
+            note => '#2 - ping-pong option --tcp',
+            pre_proc => \&te_def_pre_proc,
+            server_proc => \&te_def_server_proc,
+            server_arg => 'sr -i TARGET() --tcp',
+            client_proc => \&te_def_client_proc,
+            client_arg => 'pp -i TARGET() --tcp',
+            result_proc => \&te_def_result_proc,
+            result_arg => {
+                server => {
+                    success => ['Test end', 'interrupted by', 'exit', 'ADDR'],
+                    failure => ['Segmentation fault', 'Assertion', 'ERROR']
+                },
+                client => {
+                    success => ['Test ended', 'Summary: Latency is', 'Warmup stage \(sending a few dummy messages\)...', 'ADDR'],
+                    failure =>  ['Segmentation fault', 'Assertion', 'ERROR', 'server down'],
+                }
+            },
+            post_proc => \&te_def_post_proc,
+        },
+        {
+            name => 'tc3',
+            note => '#3 - ping-pong option -b10 --tcp',
+            pre_proc => \&te_def_pre_proc,
+            server_proc => \&te_def_server_proc,
+            server_arg => 'sr -i TARGET() --tcp',
+            client_proc => \&te_def_client_proc,
+            client_arg => 'pp -i TARGET() --tcp -b10',
+            result_proc => \&te_def_result_proc,
+            result_arg => {
+                server => {
+                    success => ['Test end', 'interrupted by', 'exit', 'ADDR'],
+                    failure => ['Segmentation fault', 'Assertion', 'ERROR']
+                },
+                client => {
+                    success => ['Test ended', 'Summary: Latency of burst of 10 messages', 'ADDR'],
+                    failure => ['Segmentation fault', 'Assertion', 'ERROR', 'server down']
+                }
+            },
+            post_proc => \&te_def_post_proc,
+        },
+        {
+            name => 'tc4',
+            note => '#4 - ping-pong option -b100 --tcp',
+            pre_proc => \&te_def_pre_proc,
+            server_proc => \&te_def_server_proc,
+            server_arg => 'sr -i TARGET() --tcp',
+            client_proc => \&te_def_client_proc,
+            client_arg => 'pp -i TARGET() --tcp -b100',
+            result_proc => \&te_def_result_proc,
+            result_arg => {
+                server => {
+                    success => ['Test end', 'interrupted by', 'exit', 'ADDR'],
+                    failure => ['Segmentation fault', 'Assertion', 'ERROR']
+                },
+                client => {
+                    success => ['Test ended', 'Summary: Latency of burst of 100 messages', 'ADDR'],
+                    failure => ['Segmentation fault', 'Assertion', 'ERROR', 'server down']
+                }
+            },
+            post_proc => \&te_def_post_proc,
+        },
+        {
+            name => 'tc5',
+            note => '#5 - ping-pong option -b500 --tcp',
+            pre_proc => \&te_def_pre_proc,
+            server_proc => \&te_def_server_proc,
+            server_arg => 'sr -i TARGET() --tcp',
+            client_proc => \&te_def_client_proc,
+            client_arg => 'pp -i TARGET() --tcp -b500',
+            result_proc => \&te_def_result_proc,
+            result_arg => {
+                server => {
+                    success => ['Test end', 'interrupted by', 'exit', 'ADDR'],
+                    failure => ['Segmentation fault', 'Assertion', 'ERROR']
+                },
+                client => {
+                    success => ['Test ended', 'Summary: Latency of burst of 500 messages', 'ADDR'],
+                    failure => ['Segmentation fault', 'Assertion', 'ERROR', 'server down']
+                }
+            },
+            post_proc => \&te_def_post_proc,
+        },
+        {
+            name => 'tc6',
+            note => '#6 - ping-pong option -t10 --tcp',
+            pre_proc => \&te_def_pre_proc,
+            server_proc => \&te_def_server_proc,
+            server_arg => 'sr -i TARGET() --tcp',
+            client_proc => \&te_def_client_proc,
+            client_arg => 'pp -i TARGET() --tcp -t10',
+            result_proc => \&te_def_result_proc,
+            result_arg => {
+                server => {
+                    success => ['Test end', 'interrupted by', 'exit', 'ADDR'],
+                    failure => ['Segmentation fault', 'Assertion', 'ERROR']
+                },
+                client => {
+                    success => ['Test ended', 'Summary: Latency is', 'RunTime=10', 'ADDR'],
+                    failure => ['Segmentation fault', 'Assertion', 'ERROR', 'server down']
+                }
+            },
+            post_proc => \&te_def_post_proc,
+        },
+        {
+            name => 'tc7',
+            note => '#7 - ping-pong option -t10 (udp) ',
+            pre_proc => \&te_def_pre_proc,
+            server_proc => \&te_def_server_proc,
+            server_arg => 'sr -i TARGET()',
+            client_proc => \&te_def_client_proc,
+            client_arg => 'pp -i TARGET() -t30',
+            result_proc => \&te_def_result_proc,
+            result_arg => {
+                server => {
+                    success => ['Test end', 'interrupted by', 'exit', 'ADDR'],
+                    failure => ['Segmentation fault', 'Assertion', 'ERROR']
+                },
+                client => {
+                    success => ['Test ended', 'Summary: Latency is', 'RunTime=30', 'ADDR'],
+                    failure => ['Segmentation fault', 'Assertion', 'ERROR', 'server down']
+                }
+            },
+            post_proc => \&te_def_post_proc,
+        },
+        {
+            name => 'tc8',
+            note => '#8 - ping-pong option -m32 --tcp',
+            pre_proc => \&te_def_pre_proc,
+            server_proc => \&te_def_server_proc,
+            server_arg => 'sr -i TARGET() --tcp',
+            client_proc => \&te_def_client_proc,
+            client_arg => 'pp -i TARGET() --tcp -m32',
+            result_proc => \&te_def_result_proc,
+            result_arg => {
+                server => {
+                    success => ['Test end', 'interrupted by', 'exit', 'ADDR'],
+                    failure => ['Segmentation fault', 'Assertion', 'ERROR']
+                },
+                client => {
+                    success => ['Test ended', 'Summary: Latency is', 'ADDR'],
+                    failure => ['Segmentation fault', 'Assertion', 'ERROR', 'server down']
+                }
+            },
+            post_proc => \&te_def_post_proc,
+        },
+        {
+            name => 'tc9',
+            note => '#9 - ping-pong option -m4096 --tcp',
+            pre_proc => \&te_def_pre_proc,
+            server_proc => \&te_def_server_proc,
+            server_arg => 'sr -i TARGET() --tcp',
+            client_proc => \&te_def_client_proc,
+            client_arg => 'pp -i TARGET() --tcp -m4096',
+            result_proc => \&te_def_result_proc,
+            result_arg => {
+                server => {
+                    success => ['Test end', 'interrupted by', 'exit', 'ADDR'],
+                    failure => ['Segmentation fault', 'Assertion', 'ERROR']
+                },
+                client => {
+                    success => ['Test ended', 'Summary: Latency is', 'ADDR'],
+                    failure => ['Segmentation fault', 'Assertion', 'ERROR', 'server down']
+                }
+            },
+            post_proc => \&te_def_post_proc,
+        },
+        {
+            name => 'tc10',
+            note => '#10 - ping-pong option --m4096 (udp)',
+            pre_proc => \&te_def_pre_proc,
+            server_proc => \&te_def_server_proc,
+            server_arg => 'sr -i TARGET()',
+            client_proc => \&te_def_client_proc,
+            client_arg => 'pp -i TARGET() -m4096',
+            result_proc => \&te_def_result_proc,
+            result_arg => {
+                server => {
+                    success => ['Test end', 'interrupted by', 'exit', 'ADDR'],
+                    failure => ['Segmentation fault', 'Assertion', 'ERROR']
+                },
+                client => {
+                    success => ['Test ended', 'Summary: Latency is', 'ADDR'],
+                    failure => ['Segmentation fault', 'Assertion', 'ERROR', 'server down']
+                }
+            },
+            post_proc => \&te_def_post_proc,
+        },
+        {
+            name => 'tc11',
+            note => '#11 - ping-pong option -r10 --tcp',
+            pre_proc => \&te_def_pre_proc,
+            server_proc => \&te_def_server_proc,
+            server_arg => 'sr -i TARGET() --tcp',
+            client_proc => \&te_def_client_proc,
+            client_arg => 'pp -i TARGET() --tcp -r10',
+            result_proc => \&te_def_result_proc,
+            result_arg => {
+                server => {
+                    success => ['Test end', 'interrupted by', 'exit', 'ADDR'],
+                    failure => ['Segmentation fault', 'Assertion', 'ERROR']
+                },
+                client => {
+                    success => ['Test ended', 'Summary: Latency is', 'ADDR'],
+                    failure => ['Segmentation fault', 'Assertion', 'ERROR', 'server down']
+                }
+            },
+            post_proc => \&te_def_post_proc,
+        },
+        {
+            name => 'tc12',
+            note => '#12 - ping-pong option -r100 --tcp',
+            pre_proc => \&te_def_pre_proc,
+            server_proc => \&te_def_server_proc,
+            server_arg => 'sr -i TARGET() --tcp',
+            client_proc => \&te_def_client_proc,
+            client_arg => 'pp -i TARGET() --tcp -r100',
+            result_proc => \&te_def_result_proc,
+            result_arg => {
+                server => {
+                    success => ['Test end', 'interrupted by', 'exit', 'ADDR'],
+                    failure => ['Segmentation fault', 'Assertion', 'ERROR']
+                },
+                client => {
+                    success => ['Test ended', 'Summary: Latency is', 'ADDR'],
+                    failure => ['Segmentation fault', 'Assertion', 'ERROR', 'server down']
+                }
+            },
+            post_proc => \&te_def_post_proc,
+        },
+        {
+            name => 'tc13',
+            note => '#13 - ping-pong option -r1024 --tcp',
+            pre_proc => \&te_def_pre_proc,
+            server_proc => \&te_def_server_proc,
+            server_arg => 'sr -i TARGET() --tcp',
+            client_proc => \&te_def_client_proc,
+            client_arg => 'pp -i TARGET() --tcp -r1024',
+            result_proc => \&te_def_result_proc,
+            result_arg => {
+                server => {
+                    success => ['Test end', 'interrupted by', 'exit', 'ADDR'],
+                    failure => ['Segmentation fault', 'Assertion', 'ERROR']
+                },
+                client => {
+                    success => ['Test ended', 'Summary: Latency is', 'ADDR'],
+                    failure => ['Segmentation fault', 'Assertion', 'ERROR', 'server down']
+                }
+            },
+            post_proc => \&te_def_post_proc,
+        },
+        {
+            name => 'tc14',
+            note => '#13 - ping-pong option -r1024 (udp)',
+            pre_proc => \&te_def_pre_proc,
+            server_proc => \&te_def_server_proc,
+            server_arg => 'sr -i TARGET()',
+            client_proc => \&te_def_client_proc,
+            client_arg => 'pp -i TARGET() -r1024',
+            result_proc => \&te_def_result_proc,
+            result_arg => {
+                server => {
+                    success => ['Test end', 'interrupted by', 'exit', 'ADDR'],
+                    failure => ['Segmentation fault', 'Assertion', 'ERROR']
+                },
+                client => {
+                    success => ['Test ended', 'Summary: Latency is', 'ADDR'],
+                    failure => ['Segmentation fault', 'Assertion', 'ERROR', 'server down']
+                }
+            },
+            post_proc => \&te_def_post_proc,
+        },
+    ];
+
+
+1;

--- a/tests/verifier/verifier.pl
+++ b/tests/verifier/verifier.pl
@@ -56,7 +56,7 @@ use TE::Common;
 use TE::Utility;
 use TE::Funclet;
 
-our ($VERSION) = "0.1.";
+our ($VERSION) = "0.3";
 
 ###########################################################
 # Set variables
@@ -341,6 +341,7 @@ sub __setup_task
     use TTP;
     use UPB;
     use TPB;
+    use UDS;
 
 	$_common->{tsuite} =
 	[ 
@@ -383,7 +384,12 @@ sub __setup_task
             name => 'tcp-pb',
             tcase => $TPB::test_suite_tcp_pb,
             note => 'playback for TCP'
-        }   
+        },
+        {
+            name => 'uds',
+            tcase => $UDS::test_suite_uds,
+            note => 'tests for Unix Domain Socket'
+        }
 	];
 }
 


### PR DESCRIPTION
Adding tests for recently Unix Domain Socket patch
* creating new `for-loop` for `test_uds_list` 
* creating new file `UDS.pm` to distinguish UDS tests from original tests 
* extends `Funclet.pm`, `Utility.pm` and `Verifier.pl` to support new tests