### PR TITLE
Fixing verifyier instable test checks

### DIFF
--- a/tests/verifier/lib/TPP.pm
+++ b/tests/verifier/lib/TPP.pm
@@ -141,7 +141,7 @@ our $test_suite_tcp_pp =
                     failure => ['Segmentation fault', 'Assertion', 'ERROR']
                 },
                 client => {
-                    success => ['Test ended', 'Summary: Latency is', 'RunTime=10'],
+                    success => ['Test ended', 'Summary: Latency is', 'RunTime='],
                     failure => ['Segmentation fault', 'Assertion', 'ERROR', 'server down']
                 }
             },
@@ -162,7 +162,7 @@ our $test_suite_tcp_pp =
                     failure => ['Segmentation fault', 'Assertion', 'ERROR']
                 },
                 client => {
-                    success => ['Test ended', 'Summary: Latency is', 'RunTime=30'],
+                    success => ['Test ended', 'Summary: Latency is', 'RunTime='],
                     failure => ['Segmentation fault', 'Assertion', 'ERROR', 'server down']
                 }
             },

--- a/tests/verifier/lib/TUL.pm
+++ b/tests/verifier/lib/TUL.pm
@@ -141,7 +141,7 @@ our $test_suite_tcp_ul =
                     failure => ['Segmentation fault', 'Assertion', 'ERROR']
                 },
                 client => {
-                    success => ['Test ended', 'Summary: Latency is', 'RunTime=10'],
+                    success => ['Test ended', 'Summary: Latency is', 'RunTime='],
                     failure => ['Segmentation fault', 'Assertion', 'ERROR', 'server down']
                 }
             },
@@ -162,7 +162,7 @@ our $test_suite_tcp_ul =
                     failure => ['Segmentation fault', 'Assertion', 'ERROR']
                 },
                 client => {
-                    success => ['Test ended', 'Summary: Latency is', 'RunTime=30'],
+                    success => ['Test ended', 'Summary: Latency is', 'RunTime='],
                     failure => ['Segmentation fault', 'Assertion', 'ERROR', 'server down']
                 }
             },

--- a/tests/verifier/lib/UDS.pm
+++ b/tests/verifier/lib/UDS.pm
@@ -141,7 +141,7 @@ our $test_suite_uds =
                     failure => ['Segmentation fault', 'Assertion', 'ERROR']
                 },
                 client => {
-                    success => ['Test ended', 'Summary: Latency is', 'RunTime=10', 'ADDR'],
+                    success => ['Test ended', 'Summary: Latency is', 'RunTime=', 'ADDR'],
                     failure => ['Segmentation fault', 'Assertion', 'ERROR', 'server down']
                 }
             },
@@ -162,7 +162,7 @@ our $test_suite_uds =
                     failure => ['Segmentation fault', 'Assertion', 'ERROR']
                 },
                 client => {
-                    success => ['Test ended', 'Summary: Latency is', 'RunTime=30', 'ADDR'],
+                    success => ['Test ended', 'Summary: Latency is', 'RunTime=', 'ADDR'],
                     failure => ['Segmentation fault', 'Assertion', 'ERROR', 'server down']
                 }
             },

--- a/tests/verifier/lib/UPP.pm
+++ b/tests/verifier/lib/UPP.pm
@@ -141,7 +141,7 @@ our $test_suite_udp_pp =
                     failure => ['Segmentation fault', 'Assertion', 'ERROR']
                 },
                 client => {
-	                success => ['Test ended', 'Summary: Latency is', 'RunTime=10'],
+	                success => ['Test ended', 'Summary: Latency is', 'RunTime='],
 	                failure => ['Segmentation fault', 'Assertion', 'ERROR', 'server down']
                 }
             },
@@ -162,7 +162,7 @@ our $test_suite_udp_pp =
                     failure => ['Segmentation fault', 'Assertion', 'ERROR']
                 },
                 client => {
-                    success => ['Test ended', 'Summary: Latency is', 'RunTime=30'],
+                    success => ['Test ended', 'Summary: Latency is', 'RunTime='],
                     failure => ['Segmentation fault', 'Assertion', 'ERROR', 'server down']
                 }
             },

--- a/tests/verifier/lib/UUL.pm
+++ b/tests/verifier/lib/UUL.pm
@@ -141,7 +141,7 @@ our $test_suite_udp_ul =
                     failure => ['Segmentation fault', 'Assertion', 'ERROR']
                 },
                 client => {
-	                success => ['Test ended', 'Summary: Latency is', 'RunTime=10'],
+	                success => ['Test ended', 'Summary: Latency is', 'RunTime='],
 	                failure => ['Segmentation fault', 'Assertion', 'ERROR', 'server down']
                 }
             },
@@ -162,7 +162,7 @@ our $test_suite_udp_ul =
                     failure => ['Segmentation fault', 'Assertion', 'ERROR']
                 },
                 client => {
-                    success => ['Test ended', 'Summary: Latency is', 'RunTime=30'],
+                    success => ['Test ended', 'Summary: Latency is', 'RunTime='],
                     failure => ['Segmentation fault', 'Assertion', 'ERROR', 'server down']
                 }
             },


### PR DESCRIPTION
Resolve tests failure such as:
sockperf: [Total Run] RunTime=9.998 sec;
When runtime is not exactly 10.

Signed-off-by: Alexander Grissik <agrissik@nvidia.com>