### PR TITLE
Add kqueue support & reintroduce FreeBSD support 

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -882,10 +882,10 @@ int Client<IoType, SwitchDataIntegrity, SwitchActivityInfo, SwitchCycleDuration,
             if (p_client_bind_addr->addr.sa_family != AF_UNSPEC) {
                 socklen_t client_bind_addr_len = g_pApp->m_const_params.client_bind_info_len;
                 std::string hostport = sockaddr_to_hostport(p_client_bind_addr);
-#if defined(__linux__) || defined(__APPLE__)
+#if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
                 struct sockaddr_store_t unix_addr;
                 socklen_t unix_addr_len;
-#endif // defined(__linux__) || defined(__APPLE__)
+#endif // defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
                 if (p_client_bind_addr->addr.sa_family == AF_UNIX && g_pApp->m_const_params.sock_type == SOCK_DGRAM) { // Need to bind localy
 #ifdef __windows__
                     log_err("AF_UNIX with DGRAM isn't supported in windows");

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1272,6 +1272,12 @@ void client_handler(handler_info *p_info) {
             break;
         }
 #endif // !__FreeBSD__ && !defined(__APPLE__)
+#if defined(__FreeBSD__) || defined(__APPLE__)
+        case KQUEUE: {
+            client_handler<IoKqueue>(p_info->fd_min, p_info->fd_max, p_info->fd_num);
+            break;
+        }
+#endif // defined(__FreeBSD__) || defined(__APPLE__)
 #ifdef USING_VMA_EXTRA_API // For VMA socketxtreme Only
         case SOCKETXTREME: {
             client_handler<IoSocketxtreme>(p_info->fd_min, p_info->fd_max, p_info->fd_num);

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -234,7 +234,12 @@ const char *handler2str(fd_block_handler_t type) {
     static const char *s_fds_handle_desc[FD_HANDLE_MAX] = { "recvfrom", "recvfrom", "select"
 #ifndef __windows__
                                                             ,
-                                                            "poll", "epoll", "kqueue",
+                                                            "poll",
+#ifdef __linux__
+                                                            "epoll",
+#elif defined(__APPLE__) || defined(__FreeBSD__)
+                                                            "kqueue",
+#endif // defined(__APPLE__) || defined(__FreeBSD__)
 #ifdef USING_VMA_EXTRA_API // For VMA socketxtreme Only
                                                             "socketxtreme"
 #endif // USING_VMA_EXTRA_API

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -234,7 +234,7 @@ const char *handler2str(fd_block_handler_t type) {
     static const char *s_fds_handle_desc[FD_HANDLE_MAX] = { "recvfrom", "recvfrom", "select"
 #ifndef __windows__
                                                             ,
-                                                            "poll", "epoll",
+                                                            "poll", "epoll", "kqueue",
 #ifdef USING_VMA_EXTRA_API // For VMA socketxtreme Only
                                                             "socketxtreme"
 #endif // USING_VMA_EXTRA_API

--- a/src/defs.h
+++ b/src/defs.h
@@ -58,9 +58,15 @@ typedef unsigned short int sa_family_t;
 #include <sys/epoll.h>
 #endif
 
-#ifdef __APPLE__
+#if defined(__FreeBSD__) || defined(__APPLE__)
 #include <sys/event.h>
-#endif
+
+#ifdef __APPLE__
+#define EV_FLAGS (EV_ADD | EV_OOBAND)
+#else // __FreeBSD__
+#define EV_FLAGS (EV_ADD)
+#endif // __FreeBSD__
+#endif // defined(__FreeBSD__) || defined(__APPLE__)
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -201,12 +207,12 @@ const uint32_t TEST_FIRST_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC = 50;
         "^[UuTt]:([A-Za-z]:[\\\\/].*)[\r\n]*"
 #define RESOLVE_ADDR_FORMAT_SOCKET                                                                 \
         "[A-Za-z]:[\\\\/].*"
-#elif defined(__linux__) || defined(__APPLE__) 
+#elif defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
 #define UNIX_DOMAIN_SOCKET_FORMAT_REG_EXP                                                          \
         "^[UuTt]:(/.+)[\r\n]"
 #define RESOLVE_ADDR_FORMAT_SOCKET                                                                 \
         "/.+"
-#endif // defined(__linux__) || defined(__APPLE__) 
+#endif // defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
 
 #define PRINT_PROTOCOL(type)                                                                       \
     ((type) == SOCK_DGRAM ? "UDP" : ((type) == SOCK_STREAM ? "TCP" : "<?>"))

--- a/src/defs.h
+++ b/src/defs.h
@@ -691,6 +691,7 @@ typedef enum { // must be coordinated with s_fds_handle_desc in common.cpp
 #ifndef __windows__
     POLL,
     EPOLL,
+    KQUEUE,
 #endif
     SOCKETXTREME,
     FD_HANDLE_MAX } fd_block_handler_t;

--- a/src/defs.h
+++ b/src/defs.h
@@ -696,8 +696,11 @@ typedef enum { // must be coordinated with s_fds_handle_desc in common.cpp
     SELECT,
 #ifndef __windows__
     POLL,
+#ifdef __linux__
     EPOLL,
+#elif defined(__APPLE__) || defined(__FreeBSD__)
     KQUEUE,
+#endif // defined(__APPLE__) || defined(__FreeBSD__)
 #endif
     SOCKETXTREME,
     FD_HANDLE_MAX } fd_block_handler_t;

--- a/src/defs.h
+++ b/src/defs.h
@@ -58,6 +58,10 @@ typedef unsigned short int sa_family_t;
 #include <sys/epoll.h>
 #endif
 
+#ifdef __APPLE__
+#include <sys/event.h>
+#endif
+
 #include <stdbool.h>
 #include <stdint.h>
 #include <unordered_map>

--- a/src/iohandlers.cpp
+++ b/src/iohandlers.cpp
@@ -300,7 +300,7 @@ int IoKqueue::prepareNetwork() {
             for (int ifd = m_fd_min; ifd <= m_fd_max; ifd++) {
                 if (g_fds_array[ifd]) {
                     print_addresses(g_fds_array[ifd], list_count);
-                    EV_SET(&mp_kqueue_changes[m_max_events], ifd, EVFILT_READ, EV_ADD | EV_OOBAND, 0, 0, 0);
+                    EV_SET(&mp_kqueue_changes[m_max_events], ifd, EVFILT_READ, EV_FLAGS, 0, 0, 0);
                     m_max_events++;
                 }
             }

--- a/src/iohandlers.h
+++ b/src/iohandlers.h
@@ -409,7 +409,7 @@ public:
                      */
                     if (active_fd_list[i] != (int)INVALID_SOCKET) {
                         if (active_fd_list[i] != ifd) {
-                            EV_SET(&mp_kqueue_changes[change_num], active_fd_list[i], EVFILT_READ, EV_ADD | EV_OOBAND, 0, 0, 0);
+                            EV_SET(&mp_kqueue_changes[change_num], active_fd_list[i], EVFILT_READ, EV_FLAGS, 0, 0, 0);
                             change_num++;
                             m_max_events++;
                         }

--- a/src/ip_address.h
+++ b/src/ip_address.h
@@ -38,12 +38,12 @@
 #include <afunix.h>
 typedef unsigned short int sa_family_t;
 
-#elif defined(__linux__) || defined(__APPLE__) 
+#elif defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <sys/un.h>      /* definitions for UNIX domain sockets */
 
-#endif // defined(__linux__) || defined(__APPLE__)
+#endif // defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
 
 #include "os_abstract.h"
 #include <functional>

--- a/src/os_abstract.h
+++ b/src/os_abstract.h
@@ -104,6 +104,7 @@ void *win_set_timer(void *p_timer);
 #include <fcntl.h>
 #include <netinet/in.h>
 #include <netdb.h>
+#include <unistd.h>
 
 #define INVALID_SOCKET (-1)
 
@@ -126,7 +127,6 @@ void *win_set_timer(void *p_timer);
 
 #elif __APPLE__
 
-#include <unistd.h>
 #include <mach/mach.h>
 #include <mach/thread_policy.h>
 #define __CPU_SETSIZE 1024                  // ported from Linux
@@ -138,7 +138,6 @@ void *win_set_timer(void *p_timer);
 
 #else
 
-#include <unistd.h>
 #include <sys/syscall.h>
 #include <endian.h>
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -422,6 +422,12 @@ void server_handler(handler_info *p_info) {
             break;
         }
 #endif // !defined(__FreeBSD__) && !defined(__APPLE__)
+#if defined(__FreeBSD__) || defined(__APPLE__)
+        case KQUEUE: {
+            server_handler<IoKqueue>(p_info->fd_min, p_info->fd_max, p_info->fd_num);
+            break;
+        }
+#endif // defined(__FreeBSD__) || defined(__APPLE__)
 #ifdef USING_VMA_EXTRA_API // VMA socketxtreme-extra-api Only
         case SOCKETXTREME: {
             server_handler<IoSocketxtreme>(p_info->fd_min, p_info->fd_max, p_info->fd_num);

--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -191,7 +191,7 @@ static const AOPT_DESC common_opt_desc[] = {
 #ifdef __windows__
       "Type of multiple file descriptors handle [s|select|r|recvfrom](default select)."
 #elif defined(__FreeBSD__) || defined(__APPLE__)
-      "Type of multiple file descriptors handle [s|select|p|poll|r|recvfrom](default select)."
+      "Type of multiple file descriptors handle [s|select|p|poll|r|recvfrom|k|kqueue](default kqueue)."
 #else
       "Type of multiple file descriptors handle "
       "[s|select|p|poll|e|epoll|r|recvfrom|x|socketxtreme](default epoll)."
@@ -204,7 +204,7 @@ static const AOPT_DESC common_opt_desc[] = {
 #ifdef __windows__
       "Set select timeout to <msec>, -1 for infinite (default is 10 msec)."
 #elif defined(__FreeBSD__) || defined(__APPLE__)
-      "Set select/poll timeout to <msec>, -1 for infinite (default is 10 msec)."
+      "Set select/poll/kqueue timeout to <msec>, -1 for infinite (default is 10 msec)."
 #else
       "Set select/poll/epoll timeout to <msec>, -1 for infinite (default is 10 msec)."
 #endif
@@ -1820,7 +1820,7 @@ static int parse_common_opt(const AOPT_OBJECT *common_obj) {
                     strncpy(feedfile_name, optarg, MAX_ARGV_SIZE);
                     feedfile_name[MAX_PATH_LENGTH - 1] = '\0';
 #if defined(__windows__) || defined(__FreeBSD__) || defined(__APPLE__)
-                    s_user_params.fd_handler_type = SELECT;
+                    s_user_params.fd_handler_type = KQUEUE;
 #else
                     s_user_params.fd_handler_type = EPOLL;
 #endif
@@ -1846,6 +1846,11 @@ static int parse_common_opt(const AOPT_OBJECT *common_obj) {
 #if !defined(__FreeBSD__) && !defined(__APPLE__)
                     if (!strcmp(fd_handle_type, "epoll") || !strcmp(fd_handle_type, "e")) {
                         s_user_params.fd_handler_type = EPOLL;
+                    } else
+#endif
+#if defined(__FreeBSD__) || defined(__APPLE__)
+                    if (!strcmp(fd_handle_type, "kqueue") || !strcmp(fd_handle_type, "k")) {
+                        s_user_params.fd_handler_type = KQUEUE;
                     } else
 #endif
                         if (!strcmp(fd_handle_type, "poll") || !strcmp(fd_handle_type, "p")) {
@@ -1966,7 +1971,7 @@ static int parse_common_opt(const AOPT_OBJECT *common_obj) {
 #ifdef __windows__
                     log_msg("'-%d' Invalid select timeout val: %s", OPT_SELECT_TIMEOUT, optarg);
 #elif defined(__FreeBSD__) || defined(__APPLE__)
-                    log_msg("'-%d' Invalid select/poll timeout val: %s", OPT_SELECT_TIMEOUT,
+                    log_msg("'-%d' Invalid select/poll/kqueue timeout val: %s", OPT_SELECT_TIMEOUT,
                             optarg);
 #else
                     log_msg("'-%d' Invalid select/poll/epoll timeout val: %s", OPT_SELECT_TIMEOUT,

--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -1819,7 +1819,9 @@ static int parse_common_opt(const AOPT_OBJECT *common_obj) {
                 if (optarg) {
                     strncpy(feedfile_name, optarg, MAX_ARGV_SIZE);
                     feedfile_name[MAX_PATH_LENGTH - 1] = '\0';
-#if defined(__windows__) || defined(__FreeBSD__) || defined(__APPLE__)
+#if defined(__windows__)
+                    s_user_params.fd_handler_type = SELECT;
+#elif defined(__FreeBSD__) || defined(__APPLE__)
                     s_user_params.fd_handler_type = KQUEUE;
 #else
                     s_user_params.fd_handler_type = EPOLL;


### PR DESCRIPTION
Hi,

I added support for kqueue-based multiplexing for macOS and FreeBSD.
To use kqueue, I also reintroduced FreeBSD support.

Implementation details:

* Add IoKqueue class and its handling code
* IoKqueue use `EV_ADD | EV_OOBAND` flags for macOS and only `EV_ADD` for FreeBSD, since FreeBSD does not support `EV_OOBAND` (similar to `EPOLLPRI`).
* The default multiplexing method is changed to `kqueue` from `select`.

In my machine, kqueue-based multiplexing shows lower latencies than poll.

Environment: FreeBSD 13.1, Intel E5-2620 v4

Using poll:

```
sockperf: == version #3.10-no.git == 
sockperf[CLIENT] send on:sockperf: using poll() to block on socket(s)

[ 0] IP = 127.0.0.1       PORT = 17000 # TCP
[ 1] IP = 127.0.0.1       PORT = 17001 # TCP
[ 2] IP = 127.0.0.1       PORT = 17002 # TCP
[ 3] IP = 127.0.0.1       PORT = 17003 # TCP
[ 4] IP = 127.0.0.1       PORT = 17004 # TCP
[ 5] IP = 127.0.0.1       PORT = 17005 # TCP
[ 6] IP = 127.0.0.1       PORT = 17006 # TCP
[ 7] IP = 127.0.0.1       PORT = 17007 # TCP
[ 8] IP = 127.0.0.1       PORT = 17008 # TCP
[ 9] IP = 127.0.0.1       PORT = 17009 # TCP
sockperf: Warmup stage (sending a few dummy messages)...
sockperf: Starting test...
sockperf: Test end (interrupted by timer)
sockperf: Test ended
sockperf: [Total Run] RunTime=1.001 sec; Warm up time=400 msec; SentMessages=38454; ReceivedMessages=38453
sockperf: ========= Printing statistics for Server No: 0
sockperf: [Valid Duration] RunTime=0.551 sec; SentMessages=21115; ReceivedMessages=21115
sockperf: ====> avg-latency=12.947 (std-dev=6.222, mean-ad=1.270, median-ad=0.674, siqr=0.549, cv=0.481, std-error=0.043, 99.0% ci=[12.837, 13.057])
sockperf: # dropped messages = 0; # duplicated messages = 0; # out-of-order messages = 0
sockperf: Summary: Latency is 12.947 usec
sockperf: Total 21115 observations; each percentile contains 211.15 observations
sockperf: ---> <MAX> observation =  871.259
sockperf: ---> percentile 99.999 =  871.259
sockperf: ---> percentile 99.990 =   62.616
sockperf: ---> percentile 99.900 =   28.380
sockperf: ---> percentile 99.000 =   19.913
sockperf: ---> percentile 90.000 =   15.375
sockperf: ---> percentile 75.000 =   13.148
sockperf: ---> percentile 50.000 =   12.416
sockperf: ---> percentile 25.000 =   12.050
sockperf: ---> <MIN> observation =   10.125
```

Using kqueue:

```
sockperf: == version #3.10-no.git == 
sockperf[CLIENT] send on:sockperf: using kqueue() to block on socket(s)

[ 0] IP = 127.0.0.1       PORT = 17000 # TCP
[ 1] IP = 127.0.0.1       PORT = 17001 # TCP
[ 2] IP = 127.0.0.1       PORT = 17002 # TCP
[ 3] IP = 127.0.0.1       PORT = 17003 # TCP
[ 4] IP = 127.0.0.1       PORT = 17004 # TCP
[ 5] IP = 127.0.0.1       PORT = 17005 # TCP
[ 6] IP = 127.0.0.1       PORT = 17006 # TCP
[ 7] IP = 127.0.0.1       PORT = 17007 # TCP
[ 8] IP = 127.0.0.1       PORT = 17008 # TCP
[ 9] IP = 127.0.0.1       PORT = 17009 # TCP
sockperf: Warmup stage (sending a few dummy messages)...
sockperf: Starting test...
sockperf: Test end (interrupted by timer)
sockperf: Test ended
sockperf: [Total Run] RunTime=1.005 sec; Warm up time=400 msec; SentMessages=49100; ReceivedMessages=49099
sockperf: ========= Printing statistics for Server No: 0
sockperf: [Valid Duration] RunTime=0.555 sec; SentMessages=28176; ReceivedMessages=28176
sockperf: ====> avg-latency=9.756 (std-dev=3.202, mean-ad=1.059, median-ad=0.993, siqr=0.772, cv=0.328, std-error=0.019, 99.0% ci=[9.707, 9.805])
sockperf: # dropped messages = 0; # duplicated messages = 0; # out-of-order messages = 0
sockperf: Summary: Latency is 9.756 usec
sockperf: Total 28176 observations; each percentile contains 281.76 observations
sockperf: ---> <MAX> observation =  473.659
sockperf: ---> percentile 99.999 =  473.659
sockperf: ---> percentile 99.990 =   53.233
sockperf: ---> percentile 99.900 =   22.983
sockperf: ---> percentile 99.000 =   15.838
sockperf: ---> percentile 90.000 =   11.676
sockperf: ---> percentile 75.000 =   10.304
sockperf: ---> percentile 50.000 =    9.416
sockperf: ---> percentile 25.000 =    8.759
sockperf: ---> <MIN> observation =    7.850

```
