### PR TITLE
Adding support for XLIO socketxtreme and callback-api

### DIFF
--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -37,7 +37,7 @@ runs_on_dockers:
   - {name: 'header-check', url: 'harbor.mellanox.com/toolbox/header_check:0.0.15', category: 'tool', arch: 'x86_64', tag: '0.0.15'}
 
 runs_on_agents:
-  - {nodeLabel: 'r-aa-fatty02', category: 'base'}
+  - {nodeLabel: 'beni09', category: 'base'}
 
 matrix:
   axes:
@@ -174,7 +174,7 @@ steps:
     containerSelector:
       - "{name: 'skip-container'}"
     agentSelector:
-      - "{nodeLabel: 'r-aa-fatty02', variant:1}"
+      - "{nodeLabel: 'beni09', variant:1}"
     run: |
       [ "x${do_cppcheck}" == "xtrue" ] && action=yes || action=no
       env WORKSPACE=$PWD TARGET=${flags} jenkins_test_cppcheck=${action} ./contrib/test_jenkins.sh
@@ -191,7 +191,7 @@ steps:
     containerSelector:
       - "{name: 'skip-container'}"
     agentSelector:
-      - "{nodeLabel: 'r-aa-fatty02', variant:1}"
+      - "{nodeLabel: 'beni09', variant:1}"
     run: |
       [ "x${do_csbuild}" == "xtrue" ] && action=yes || action=no
       env WORKSPACE=$PWD TARGET=${flags} jenkins_test_csbuild=${action} ./contrib/test_jenkins.sh
@@ -208,7 +208,7 @@ steps:
     containerSelector:
       - "{name: 'skip-container'}"
     agentSelector:
-      - "{nodeLabel: 'r-aa-fatty02'}"
+      - "{nodeLabel: 'beni09'}"
     run: |
       [ "x${do_gtest}" == "xtrue" ] && action=yes || action=no
       env WORKSPACE=$PWD TARGET=${flags} jenkins_test_gtest=${action} ./contrib/test_jenkins.sh
@@ -227,7 +227,7 @@ steps:
     containerSelector:
       - "{name: 'skip-container'}"
     agentSelector:
-      - "{nodeLabel: 'r-aa-fatty02', variant:1}"
+      - "{nodeLabel: 'beni09', variant:1}"
     run: |
       [ "x${do_test}" == "xtrue" ] && action=yes || action=no
       env WORKSPACE=$PWD TARGET=${flags} jenkins_test_run=${action} ./contrib/test_jenkins.sh

--- a/doc/main.dox
+++ b/doc/main.dox
@@ -144,8 +144,8 @@ sockperf: [tid 4805] using epoll() to block on socket(s)
          --recv_looping_num     -Set sockperf to loop over recvfrom() until EAGAIN or <N> good received packets, -1 for infinite, must be used with --nonblocked (default 1).
          --dontwarmup           -Don't send warm up messages on start.
          --pre-warmup-wait      -Time to wait before sending warm up messages (seconds).
-         --zcopyread,--vmazcopyread
-                                -Use VMA's zero copy reads API (See VMA's readme).
+         --zcopyread
+                                -Use zero copy reads API (See VMA/XLIO readme).
          --daemonize            -Run as daemon.
          --no-rdtsc             -Don't use register when taking time; instead use monotonic clock.
          --load-vma             -Load VMA dynamically even when LD_PRELOAD was not used.
@@ -161,8 +161,8 @@ sockperf: [tid 4805] using epoll() to block on socket(s)
 @code
          --threads-num          -Run <N> threads on server side (requires '-f' option).
          --cpu-affinity         -Set threads affinity to the given core ids in list format (see: cat /proc/cpuinfo).
-         --rxfiltercb,--vmarxfiltercb
-                                -Use VMA's receive path message filter callback API (See VMA's readme).
+         --rxfiltercb
+                                -Use receive path message filter callback API (See VMA/XLIO readme).
          --force-unicast-reply  -Force server to reply via unicast.
          --dont-reply           -Server won't reply to the client messages.
  -m      --msg-size             -Set maximum message size that the server can receive <size> bytes (default 65507).

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -698,24 +698,24 @@ ClientBase::~ClientBase() {
 }
 
 //------------------------------------------------------------------------------
-template <class IoType, class SwitchDataIntegrity,
+template <class IoType,
           class SwitchCycleDuration, class SwitchMsgSize, class PongModeCare>
-Client<IoType, SwitchDataIntegrity, SwitchCycleDuration, SwitchMsgSize,
+Client<IoType, SwitchCycleDuration, SwitchMsgSize,
        PongModeCare>::Client(int _fd_min, int _fd_max, int _fd_num)
     : ClientBase(), m_ioHandler(_fd_min, _fd_max, _fd_num), m_pongModeCare(m_pMsgRequest) {
     os_thread_init(&m_receiverTid);
 }
 
 //------------------------------------------------------------------------------
-template <class IoType, class SwitchDataIntegrity,
+template <class IoType,
           class SwitchCycleDuration, class SwitchMsgSize, class PongModeCare>
-Client<IoType, SwitchDataIntegrity, SwitchCycleDuration, SwitchMsgSize,
+Client<IoType, SwitchCycleDuration, SwitchMsgSize,
        PongModeCare>::~Client() {}
 
 //------------------------------------------------------------------------------
-template <class IoType, class SwitchDataIntegrity,
+template <class IoType,
           class SwitchCycleDuration, class SwitchMsgSize, class PongModeCare>
-void Client<IoType, SwitchDataIntegrity, SwitchCycleDuration, SwitchMsgSize,
+void Client<IoType, SwitchCycleDuration, SwitchMsgSize,
             PongModeCare>::client_receiver_thread() {
     while (!g_b_exit) {
         client_receive();
@@ -730,9 +730,9 @@ void *client_receiver_thread(void *arg) {
 }
 
 //------------------------------------------------------------------------------
-template <class IoType, class SwitchDataIntegrity,
+template <class IoType,
           class SwitchCycleDuration, class SwitchMsgSize, class PongModeCare>
-void Client<IoType, SwitchDataIntegrity, SwitchCycleDuration, SwitchMsgSize,
+void Client<IoType, SwitchCycleDuration, SwitchMsgSize,
             PongModeCare>::cleanupAfterLoop() {
     usleep(100 * 1000); // 0.1 sec - wait for rx packets for last sends (in normal flow)
     if (m_receiverTid.tid) {
@@ -879,9 +879,9 @@ static int _connect_check(int ifd, int timeout_ms) {
 #undef POLL_TIMEOUT_MS
 
 //------------------------------------------------------------------------------
-template <class IoType, class SwitchDataIntegrity,
+template <class IoType,
           class SwitchCycleDuration, class SwitchMsgSize, class PongModeCare>
-int Client<IoType, SwitchDataIntegrity, SwitchCycleDuration, SwitchMsgSize,
+int Client<IoType, SwitchCycleDuration, SwitchMsgSize,
            PongModeCare>::initBeforeLoop() {
     int rc = SOCKPERF_ERR_NONE;
     if (g_b_exit) return rc;
@@ -1048,9 +1048,9 @@ int Client<IoType, SwitchDataIntegrity, SwitchCycleDuration, SwitchMsgSize,
 }
 
 //------------------------------------------------------------------------------
-template <class IoType, class SwitchDataIntegrity,
+template <class IoType,
           class SwitchCycleDuration, class SwitchMsgSize, class PongModeCare>
-void Client<IoType, SwitchDataIntegrity, SwitchCycleDuration, SwitchMsgSize,
+void Client<IoType, SwitchCycleDuration, SwitchMsgSize,
             PongModeCare>::doSendThenReceiveLoop() {
     if (g_pApp->m_const_params.measurement == TIME_BASED) {
         // cycle through all set fds in the array (with wrap around to beginning)
@@ -1115,9 +1115,9 @@ void Client<IoType, SwitchDataIntegrity, SwitchCycleDuration, SwitchMsgSize,
 }
 
 //------------------------------------------------------------------------------
-template <class IoType, class SwitchDataIntegrity,
+template <class IoType,
           class SwitchCycleDuration, class SwitchMsgSize, class PongModeCare>
-void Client<IoType, SwitchDataIntegrity, SwitchCycleDuration, SwitchMsgSize,
+void Client<IoType, SwitchCycleDuration, SwitchMsgSize,
             PongModeCare>::doSendLoop() {
     // cycle through all set fds in the array (with wrap around to beginning)
     for (int curr_fds = m_ioHandler.m_fd_min; !g_b_exit; curr_fds = g_fds_array[curr_fds]->next_fd)
@@ -1138,9 +1138,9 @@ static inline void playbackCycleDurationWait(const TicksDuration &i_cycleDuratio
 }
 
 //------------------------------------------------------------------------------
-template <class IoType, class SwitchDataIntegrity,
+template <class IoType,
           class SwitchCycleDuration, class SwitchMsgSize, class PongModeCare>
-void Client<IoType, SwitchDataIntegrity, SwitchCycleDuration, SwitchMsgSize,
+void Client<IoType, SwitchCycleDuration, SwitchMsgSize,
             PongModeCare>::doPlayback() {
     static const bool is_exec_activity_info =
         (g_pApp->m_const_params.packetrate_stats_print_ratio > 0);
@@ -1176,9 +1176,9 @@ void Client<IoType, SwitchDataIntegrity, SwitchCycleDuration, SwitchMsgSize,
 }
 
 //------------------------------------------------------------------------------
-template <class IoType, class SwitchDataIntegrity,
+template <class IoType,
           class SwitchCycleDuration, class SwitchMsgSize, class PongModeCare>
-void Client<IoType, SwitchDataIntegrity, SwitchCycleDuration, SwitchMsgSize,
+void Client<IoType, SwitchCycleDuration, SwitchMsgSize,
             PongModeCare>::doHandler() {
     int rc = SOCKPERF_ERR_NONE;
 
@@ -1197,63 +1197,55 @@ void Client<IoType, SwitchDataIntegrity, SwitchCycleDuration, SwitchMsgSize,
 }
 
 //------------------------------------------------------------------------------
-template <class IoType, class SwitchDataIntegrity,
+template <class IoType,
           class SwitchCycleDuration, class SwitchMsgSize, class PongModeCare>
 void client_handler(int _fd_min, int _fd_max, int _fd_num) {
-    Client<IoType, SwitchDataIntegrity, SwitchCycleDuration, SwitchMsgSize,
+    Client<IoType, SwitchCycleDuration, SwitchMsgSize,
            PongModeCare> c(_fd_min, _fd_max, _fd_num);
     c.doHandler();
 }
 
 //------------------------------------------------------------------------------
-template <class IoType, class SwitchDataIntegrity,
+template <class IoType,
           class SwitchCycleDuration, class SwitchMsgSize>
 void client_handler(int _fd_min, int _fd_max, int _fd_num) {
     if (g_pApp->m_const_params.b_stream)
-        client_handler<IoType, SwitchDataIntegrity, SwitchCycleDuration,
+        client_handler<IoType, SwitchCycleDuration,
                        SwitchMsgSize, PongModeNever>(_fd_min, _fd_max, _fd_num);
     else if (g_pApp->m_const_params.reply_every == 1)
-        client_handler<IoType, SwitchDataIntegrity, SwitchCycleDuration,
+        client_handler<IoType, SwitchCycleDuration,
                        SwitchMsgSize, PongModeAlways>(_fd_min, _fd_max, _fd_num);
     else
-        client_handler<IoType, SwitchDataIntegrity, SwitchCycleDuration,
+        client_handler<IoType, SwitchCycleDuration,
                        SwitchMsgSize, PongModeNormal>(_fd_min, _fd_max, _fd_num);
 }
 
 //------------------------------------------------------------------------------
-template <class IoType, class SwitchDataIntegrity,
+template <class IoType,
           class SwitchCycleDuration>
 void client_handler(int _fd_min, int _fd_max, int _fd_num) {
     if (g_pApp->m_const_params.msg_size_range > 0)
-        client_handler<IoType, SwitchDataIntegrity, SwitchCycleDuration,
+        client_handler<IoType, SwitchCycleDuration,
                        SwitchOnMsgSize>(_fd_min, _fd_max, _fd_num);
     else
-        client_handler<IoType, SwitchDataIntegrity, SwitchCycleDuration,
+        client_handler<IoType, SwitchCycleDuration,
                        SwitchOff>(_fd_min, _fd_max, _fd_num);
 }
 
 //------------------------------------------------------------------------------
-template <class IoType, class SwitchDataIntegrity>
+template <class IoType>
 void client_handler(int _fd_min, int _fd_max, int _fd_num) {
     if (g_pApp->m_const_params.cycleDuration > TicksDuration::TICKS0) {
         if (g_pApp->m_const_params.dummy_mps) {
-            client_handler<IoType, SwitchDataIntegrity, SwitchOnDummySend>(
+            client_handler<IoType, SwitchOnDummySend>(
                 _fd_min, _fd_max, _fd_num);
         } else {
-            client_handler<IoType, SwitchDataIntegrity, SwitchOnCycleDuration>(
+            client_handler<IoType, SwitchOnCycleDuration>(
                 _fd_min, _fd_max, _fd_num);
         }
     } else
-        client_handler<IoType, SwitchDataIntegrity, SwitchOff>(_fd_min, _fd_max,
+        client_handler<IoType, SwitchOff>(_fd_min, _fd_max,
                                                                                    _fd_num);
-}
-
-//------------------------------------------------------------------------------
-template <class IoType> void client_handler(int _fd_min, int _fd_max, int _fd_num) {
-    if (g_pApp->m_const_params.data_integrity)
-        client_handler<IoType, SwitchOnDataIntegrity>(_fd_min, _fd_max, _fd_num);
-    else
-        client_handler<IoType, SwitchOff>(_fd_min, _fd_max, _fd_num);
 }
 
 //------------------------------------------------------------------------------

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -698,25 +698,19 @@ ClientBase::~ClientBase() {
 }
 
 //------------------------------------------------------------------------------
-template <class IoType,
-          class SwitchCycleDuration, class SwitchMsgSize, class PongModeCare>
-Client<IoType, SwitchCycleDuration, SwitchMsgSize,
-       PongModeCare>::Client(int _fd_min, int _fd_max, int _fd_num)
+template <class IoType, class SwitchCycleDuration, class PongModeCare>
+Client<IoType, SwitchCycleDuration, PongModeCare>::Client(int _fd_min, int _fd_max, int _fd_num)
     : ClientBase(), m_ioHandler(_fd_min, _fd_max, _fd_num), m_pongModeCare(m_pMsgRequest) {
     os_thread_init(&m_receiverTid);
 }
 
 //------------------------------------------------------------------------------
-template <class IoType,
-          class SwitchCycleDuration, class SwitchMsgSize, class PongModeCare>
-Client<IoType, SwitchCycleDuration, SwitchMsgSize,
-       PongModeCare>::~Client() {}
+template <class IoType, class SwitchCycleDuration, class PongModeCare>
+Client<IoType, SwitchCycleDuration, PongModeCare>::~Client() {}
 
 //------------------------------------------------------------------------------
-template <class IoType,
-          class SwitchCycleDuration, class SwitchMsgSize, class PongModeCare>
-void Client<IoType, SwitchCycleDuration, SwitchMsgSize,
-            PongModeCare>::client_receiver_thread() {
+template <class IoType, class SwitchCycleDuration, class PongModeCare>
+void Client<IoType, SwitchCycleDuration, PongModeCare>::client_receiver_thread() {
     while (!g_b_exit) {
         client_receive();
     }
@@ -730,10 +724,8 @@ void *client_receiver_thread(void *arg) {
 }
 
 //------------------------------------------------------------------------------
-template <class IoType,
-          class SwitchCycleDuration, class SwitchMsgSize, class PongModeCare>
-void Client<IoType, SwitchCycleDuration, SwitchMsgSize,
-            PongModeCare>::cleanupAfterLoop() {
+template <class IoType, class SwitchCycleDuration, class PongModeCare>
+void Client<IoType, SwitchCycleDuration, PongModeCare>::cleanupAfterLoop() {
     usleep(100 * 1000); // 0.1 sec - wait for rx packets for last sends (in normal flow)
     if (m_receiverTid.tid) {
         os_thread_kill(&m_receiverTid);
@@ -879,10 +871,8 @@ static int _connect_check(int ifd, int timeout_ms) {
 #undef POLL_TIMEOUT_MS
 
 //------------------------------------------------------------------------------
-template <class IoType,
-          class SwitchCycleDuration, class SwitchMsgSize, class PongModeCare>
-int Client<IoType, SwitchCycleDuration, SwitchMsgSize,
-           PongModeCare>::initBeforeLoop() {
+template <class IoType, class SwitchCycleDuration, class PongModeCare>
+int Client<IoType, SwitchCycleDuration, PongModeCare>::initBeforeLoop() {
     int rc = SOCKPERF_ERR_NONE;
     if (g_b_exit) return rc;
 
@@ -1048,10 +1038,8 @@ int Client<IoType, SwitchCycleDuration, SwitchMsgSize,
 }
 
 //------------------------------------------------------------------------------
-template <class IoType,
-          class SwitchCycleDuration, class SwitchMsgSize, class PongModeCare>
-void Client<IoType, SwitchCycleDuration, SwitchMsgSize,
-            PongModeCare>::doSendThenReceiveLoop() {
+template <class IoType, class SwitchCycleDuration, class PongModeCare>
+void Client<IoType, SwitchCycleDuration, PongModeCare>::doSendThenReceiveLoop() {
     if (g_pApp->m_const_params.measurement == TIME_BASED) {
         // cycle through all set fds in the array (with wrap around to beginning)
         for (int curr_fds = m_ioHandler.m_fd_min; !g_b_exit; curr_fds = g_fds_array[curr_fds]->next_fd)
@@ -1115,10 +1103,8 @@ void Client<IoType, SwitchCycleDuration, SwitchMsgSize,
 }
 
 //------------------------------------------------------------------------------
-template <class IoType,
-          class SwitchCycleDuration, class SwitchMsgSize, class PongModeCare>
-void Client<IoType, SwitchCycleDuration, SwitchMsgSize,
-            PongModeCare>::doSendLoop() {
+template <class IoType, class SwitchCycleDuration, class PongModeCare>
+void Client<IoType, SwitchCycleDuration, PongModeCare>::doSendLoop() {
     // cycle through all set fds in the array (with wrap around to beginning)
     for (int curr_fds = m_ioHandler.m_fd_min; !g_b_exit; curr_fds = g_fds_array[curr_fds]->next_fd)
         client_send_burst(curr_fds);
@@ -1138,10 +1124,8 @@ static inline void playbackCycleDurationWait(const TicksDuration &i_cycleDuratio
 }
 
 //------------------------------------------------------------------------------
-template <class IoType,
-          class SwitchCycleDuration, class SwitchMsgSize, class PongModeCare>
-void Client<IoType, SwitchCycleDuration, SwitchMsgSize,
-            PongModeCare>::doPlayback() {
+template <class IoType, class SwitchCycleDuration, class PongModeCare>
+void Client<IoType, SwitchCycleDuration, PongModeCare>::doPlayback() {
     static const bool is_exec_activity_info =
         (g_pApp->m_const_params.packetrate_stats_print_ratio > 0);
 
@@ -1176,10 +1160,8 @@ void Client<IoType, SwitchCycleDuration, SwitchMsgSize,
 }
 
 //------------------------------------------------------------------------------
-template <class IoType,
-          class SwitchCycleDuration, class SwitchMsgSize, class PongModeCare>
-void Client<IoType, SwitchCycleDuration, SwitchMsgSize,
-            PongModeCare>::doHandler() {
+template <class IoType, class SwitchCycleDuration, class PongModeCare>
+void Client<IoType, SwitchCycleDuration, PongModeCare>::doHandler() {
     int rc = SOCKPERF_ERR_NONE;
 
     rc = initBeforeLoop();
@@ -1197,39 +1179,24 @@ void Client<IoType, SwitchCycleDuration, SwitchMsgSize,
 }
 
 //------------------------------------------------------------------------------
-template <class IoType,
-          class SwitchCycleDuration, class SwitchMsgSize, class PongModeCare>
+template <class IoType, class SwitchCycleDuration, class PongModeCare>
 void client_handler(int _fd_min, int _fd_max, int _fd_num) {
-    Client<IoType, SwitchCycleDuration, SwitchMsgSize,
-           PongModeCare> c(_fd_min, _fd_max, _fd_num);
+    Client<IoType, SwitchCycleDuration, PongModeCare> c(_fd_min, _fd_max, _fd_num);
     c.doHandler();
 }
 
 //------------------------------------------------------------------------------
-template <class IoType,
-          class SwitchCycleDuration, class SwitchMsgSize>
+template <class IoType, class SwitchCycleDuration>
 void client_handler(int _fd_min, int _fd_max, int _fd_num) {
     if (g_pApp->m_const_params.b_stream)
         client_handler<IoType, SwitchCycleDuration,
-                       SwitchMsgSize, PongModeNever>(_fd_min, _fd_max, _fd_num);
+                       PongModeNever>(_fd_min, _fd_max, _fd_num);
     else if (g_pApp->m_const_params.reply_every == 1)
         client_handler<IoType, SwitchCycleDuration,
-                       SwitchMsgSize, PongModeAlways>(_fd_min, _fd_max, _fd_num);
+                       PongModeAlways>(_fd_min, _fd_max, _fd_num);
     else
         client_handler<IoType, SwitchCycleDuration,
-                       SwitchMsgSize, PongModeNormal>(_fd_min, _fd_max, _fd_num);
-}
-
-//------------------------------------------------------------------------------
-template <class IoType,
-          class SwitchCycleDuration>
-void client_handler(int _fd_min, int _fd_max, int _fd_num) {
-    if (g_pApp->m_const_params.msg_size_range > 0)
-        client_handler<IoType, SwitchCycleDuration,
-                       SwitchOnMsgSize>(_fd_min, _fd_max, _fd_num);
-    else
-        client_handler<IoType, SwitchCycleDuration,
-                       SwitchOff>(_fd_min, _fd_max, _fd_num);
+                       PongModeNormal>(_fd_min, _fd_max, _fd_num);
 }
 
 //------------------------------------------------------------------------------

--- a/src/client.h
+++ b/src/client.h
@@ -50,8 +50,7 @@ protected:
 
 //==============================================================================
 //==============================================================================
-template <class IoType,
-          class SwitchCycleDuration, class SwitchMsgSize, class PongModeCare>
+template <class IoType, class SwitchCycleDuration, class PongModeCare>
 class Client : public ClientBase {
 private:
     os_thread_t m_receiverTid;
@@ -61,21 +60,20 @@ private:
     SwitchOnDataIntegrity m_switchDataIntegrity;
     SwitchOnActivityInfo m_switchActivityInfo;
     SwitchCycleDuration m_switchCycleDuration; // SwitchOnDummySend | SwitchOnCycleDuration | SwitchOff
-    SwitchMsgSize m_switchMsgSize; // SwitchOnMsgSize | SwitchOff
+    SwitchOnMsgSize m_switchMsgSize;
     PongModeCare m_pongModeCare; // has msg_sendto() method and can be one of: PongModeNormal,
                                  // PongModeAlways, PongModeNever
 
     class ClientMessageHandlerCallback {
-        Client<IoType,
-              SwitchCycleDuration, SwitchMsgSize, PongModeCare> &m_client;
+        Client<IoType, SwitchCycleDuration, PongModeCare> &m_client;
         int m_ifd;
         struct sockaddr_store_t &m_recvfrom_addr;
         socklen_t m_recvfrom_addrlen;
         int m_receiveCount;
 
     public:
-        inline ClientMessageHandlerCallback(Client<IoType,
-                SwitchCycleDuration, SwitchMsgSize, PongModeCare> &client,
+        inline ClientMessageHandlerCallback(
+                Client<IoType, SwitchCycleDuration, PongModeCare> &client,
                 int ifd, struct sockaddr_store_t &recvfrom_addr,
                 socklen_t recvfrom_addrlen) :
             m_client(client),
@@ -345,8 +343,13 @@ private:
         static const bool is_exec_activity_info =
             (g_pApp->m_const_params.packetrate_stats_print_ratio > 0);
 
+        static const bool is_exec_msg_size =
+            (g_pApp->m_const_params.msg_size_range > 0);
+
         // init
-        m_switchMsgSize.execute(m_pMsgRequest);
+        if (unlikely(is_exec_msg_size)) {
+            m_switchMsgSize.execute(m_pMsgRequest);
+        }
 
         // idle
         m_switchCycleDuration.execute(m_pMsgRequest, ifd);

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -240,9 +240,9 @@ const char *handler2str(fd_block_handler_t type) {
 #elif defined(__APPLE__) || defined(__FreeBSD__)
                                                             "kqueue",
 #endif // defined(__APPLE__) || defined(__FreeBSD__)
-#ifdef USING_VMA_EXTRA_API // For VMA socketxtreme Only
+#ifdef USING_EXTRA_API // For socketxtreme Only
                                                             "socketxtreme"
-#endif // USING_VMA_EXTRA_API
+#endif // USING_EXTRA_API
 #endif // !WIN32
     };
 

--- a/src/defs.cpp
+++ b/src/defs.cpp
@@ -42,11 +42,6 @@ TicksTime g_cycleStartTime;
 debug_level_t g_debug_level = LOG_LVL_INFO;
 
 #ifdef USING_EXTRA_API
-#ifdef USING_VMA_EXTRA_API // VMA
-struct vma_buff_t *g_vma_buff = NULL;
-struct vma_completion_t *g_vma_comps;
-#endif // USING_VMA_EXTRA_API
-
 ZeroCopyData::ZeroCopyData() : m_pkt_buf(NULL), m_pkts(NULL) {}
 
 void ZeroCopyData::allocate() { m_pkt_buf = (unsigned char *)MALLOC(Message::getMaxSize()); }

--- a/src/defs.cpp
+++ b/src/defs.cpp
@@ -41,7 +41,7 @@ TicksTime g_cycleStartTime;
 
 debug_level_t g_debug_level = LOG_LVL_INFO;
 
-#if defined(USING_VMA_EXTRA_API) || defined (USING_XLIO_EXTRA_API)
+#ifdef USING_EXTRA_API
 #ifdef USING_VMA_EXTRA_API // VMA
 struct vma_buff_t *g_vma_buff = NULL;
 struct vma_completion_t *g_vma_comps;
@@ -56,7 +56,7 @@ ZeroCopyData::~ZeroCopyData() {
 }
 
 zeroCopyMap g_zeroCopyData;
-#endif // USING_VMA_EXTRA_API || USING_XLIO_EXTRA_API
+#endif // USING_EXTRA_API
 
 uint32_t MPS_MAX = MPS_MAX_UL; // will be overwrite at runtime in case of ping-pong test
 PacketTimes *g_pPacketTimes = NULL;

--- a/src/defs.h
+++ b/src/defs.h
@@ -107,6 +107,10 @@ typedef unsigned short int sa_family_t;
 #include "playback.h"
 #include "ip_address.h"
 
+#if defined(USING_VMA_EXTRA_API) || defined (USING_XLIO_EXTRA_API)
+#define USING_EXTRA_API
+#endif // USING_VMA_EXTRA_API || USING_XLIO_EXTRA_API
+
 #if !defined(__windows__) && !defined(__FreeBSD__) && !defined(__APPLE__)
 #include "vma-xlio-redirect.h"
 #ifdef USING_VMA_EXTRA_API // VMA
@@ -186,9 +190,9 @@ const uint32_t TEST_FIRST_CONNECTION_FIRST_PACKET_TTL_THRESHOLD_MSEC = 50;
 #define DUMMY_PORT 57341
 #define MAX_ACTIVE_FD_NUM                                                                          \
     max_fds_num /* maximum number of active connection to the single TCP addr:port */
-#ifdef USING_VMA_EXTRA_API // For VMA socketxtreme Only
-#define MAX_VMA_COMPS 1024 /* maximum size for the VMA completions array for VMA Poll */
-#endif // USING_VMA_EXTRA_API
+#ifdef USING_EXTRA_API // For VMA socketxtreme Only
+#define MAX_SOCKETXTREME_COMPS 1024 /* maximum size for socketxtreme poll completions array */
+#endif // USING_EXTRA_API
 
 #ifndef MAX_PATH_LENGTH
 #define MAX_PATH_LENGTH 1024
@@ -498,7 +502,7 @@ extern TicksTime g_cycleStartTime;
 
 extern debug_level_t g_debug_level;
 
-#if defined(USING_VMA_EXTRA_API) || defined(USING_XLIO_EXTRA_API)
+#ifdef USING_EXTRA_API
 #ifdef USING_VMA_EXTRA_API // VMA
 extern struct vma_buff_t *g_vma_buff;
 extern struct vma_completion_t *g_vma_comps;
@@ -514,7 +518,7 @@ public:
 // map from fd to zeroCopyData
 typedef std::map<int, ZeroCopyData *> zeroCopyMap;
 extern zeroCopyMap g_zeroCopyData;
-#endif // USING_VMA_EXTRA_API || USING_XLIO_EXTRA_API
+#endif // USING_EXTRA_API
 
 class Message;
 
@@ -649,7 +653,7 @@ struct equal_to<struct sockaddr_store_t> :
 
 #ifdef USING_VMA_EXTRA_API // VMA socketxtreme-extra-api Only
 struct vma_ring_comps {
-    vma_completion_t vma_comp_list[MAX_VMA_COMPS];
+    vma_completion_t vma_comp_list[MAX_SOCKETXTREME_COMPS];
     int vma_comp_list_size;
     bool is_freed;
 };

--- a/src/input_handlers.h
+++ b/src/input_handlers.h
@@ -119,7 +119,7 @@ public:
     }
 };
 
-#if defined(USING_VMA_EXTRA_API) || defined(USING_XLIO_EXTRA_API)
+#ifdef USING_EXTRA_API
 typedef int(* recvfrom_zcopy_func_t)(int __fd, void *__buf, size_t __nbytes, int *__flags,
                                      struct sockaddr *__from, socklen_t *__fromlen);
 
@@ -311,6 +311,6 @@ public:
 };
 #endif // USING_XLIO_EXTRA_API
 
-#endif // USING_VMA_EXTRA_API || USING_XLIO_EXTRA_API
+#endif // USING_EXTRA_API
 
 #endif // INPUT_HANDLERS_H_

--- a/src/iohandlers.h
+++ b/src/iohandlers.h
@@ -512,7 +512,7 @@ public:
             }
             m_rings_vma_comps_map_itr->second->vma_comp_list_size = g_vma_api->socketxtreme_poll(
                 ring_fd, (vma_completion_t *)(&m_rings_vma_comps_map_itr->second->vma_comp_list),
-                MAX_VMA_COMPS, 0);
+                MAX_SOCKETXTREME_COMPS, 0);
 
             if (m_rings_vma_comps_map_itr->second->vma_comp_list_size > 0) {
                 m_vma_comps_queue.push(ring_fd);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -28,7 +28,6 @@
 
 #include "server.h"
 #include "iohandlers.h"
-#include "switches.h"
 #include <memory>
 
 // static members initialization
@@ -162,17 +161,17 @@ void ServerBase::cleanupAfterLoop() {
 //==============================================================================
 
 //------------------------------------------------------------------------------
-template <class IoType, class SwitchActivityInfo, class SwitchCalcGaps>
-Server<IoType, SwitchActivityInfo, SwitchCalcGaps>::Server(int _fd_min, int _fd_max, int _fd_num)
+template <class IoType, class SwitchCalcGaps>
+Server<IoType, SwitchCalcGaps>::Server(int _fd_min, int _fd_max, int _fd_num)
     : ServerBase(m_ioHandler), m_ioHandler(_fd_min, _fd_max, _fd_num) {}
 
 //------------------------------------------------------------------------------
-template <class IoType, class SwitchActivityInfo, class SwitchCalcGaps>
-Server<IoType, SwitchActivityInfo, SwitchCalcGaps>::~Server() {}
+template <class IoType, class SwitchCalcGaps>
+Server<IoType, SwitchCalcGaps>::~Server() {}
 
 //------------------------------------------------------------------------------
-template <class IoType, class SwitchActivityInfo, class SwitchCalcGaps>
-void Server<IoType, SwitchActivityInfo, SwitchCalcGaps>::doLoop() {
+template <class IoType, class SwitchCalcGaps>
+void Server<IoType, SwitchCalcGaps>::doLoop() {
     int numReady = 0;
     int actual_fd = 0;
 
@@ -242,8 +241,8 @@ void Server<IoType, SwitchActivityInfo, SwitchCalcGaps>::doLoop() {
 }
 
 //------------------------------------------------------------------------------
-template <class IoType, class SwitchActivityInfo, class SwitchCalcGaps>
-int Server<IoType, SwitchActivityInfo, SwitchCalcGaps>::server_accept(int ifd) {
+template <class IoType, class SwitchCalcGaps>
+int Server<IoType, SwitchCalcGaps>::server_accept(int ifd) {
     bool do_accept = false;
     int active_ifd = ifd;
 
@@ -348,25 +347,17 @@ int Server<IoType, SwitchActivityInfo, SwitchCalcGaps>::server_accept(int ifd) {
 }
 
 //------------------------------------------------------------------------------
-template <class IoType, class SwitchActivityInfo, class SwitchCheckGaps>
+template <class IoType, class SwitchCheckGaps>
 void server_handler(int _fd_min, int _fd_max, int _fd_num) {
-    Server<IoType, SwitchActivityInfo, SwitchCheckGaps> s(_fd_min, _fd_max, _fd_num);
+    Server<IoType, SwitchCheckGaps> s(_fd_min, _fd_max, _fd_num);
     s.doHandler();
 }
 
 //------------------------------------------------------------------------------
-template <class IoType, class SwitchActivityInfo>
+template <class IoType>
 void server_handler(int _fd_min, int _fd_max, int _fd_num) {
     if (g_pApp->m_const_params.b_server_detect_gaps)
-        server_handler<IoType, SwitchActivityInfo, SwitchOnCalcGaps>(_fd_min, _fd_max, _fd_num);
-    else
-        server_handler<IoType, SwitchActivityInfo, SwitchOff>(_fd_min, _fd_max, _fd_num);
-}
-
-//------------------------------------------------------------------------------
-template <class IoType> void server_handler(int _fd_min, int _fd_max, int _fd_num) {
-    if (g_pApp->m_const_params.packetrate_stats_print_ratio > 0)
-        server_handler<IoType, SwitchOnActivityInfo>(_fd_min, _fd_max, _fd_num);
+        server_handler<IoType, SwitchOnCalcGaps>(_fd_min, _fd_max, _fd_num);
     else
         server_handler<IoType, SwitchOff>(_fd_min, _fd_max, _fd_num);
 }

--- a/src/server.h
+++ b/src/server.h
@@ -101,7 +101,8 @@ private:
     template <typename T = IoType>
     inline std::enable_if_t<!(is_vma_bufftype<T>{} || is_xlio_bufftype<T>{}), int>
     get_active_ifd(int ifd, struct sockaddr *addr, socklen_t *addr_size) {
-        return accept(ifd, addr, addr_size); 
+        // Casting to int for Windows.
+        return static_cast<int>(accept(ifd, addr, addr_size));
     }
 
     template <typename T = IoType>

--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -2424,7 +2424,7 @@ void cleanup() {
     if (s_user_params.select_timeout) {
         FREE(s_user_params.select_timeout);
     }
-#if defined(USING_VMA_EXTRA_API) || defined(USING_XLIO_EXTRA_API)
+#ifdef USING_EXTRA_API
     if ((g_vma_api || g_xlio_api) && s_user_params.is_zcopyread) {
         zeroCopyMap::iterator it;
         while ((it = g_zeroCopyData.begin()) != g_zeroCopyData.end()) {
@@ -2432,7 +2432,7 @@ void cleanup() {
             g_zeroCopyData.erase(it);
         }
     }
-#endif // USING_VMA_EXTRA_API || USING_XLIO_EXTRA_API
+#endif // USING_EXTRA_API
 
     if (g_fds_array) {
         FREE(g_fds_array);
@@ -3046,7 +3046,7 @@ int prepare_socket(int fd, struct fds_data *p_data)
         rc = sock_set_tos(fd);
     }
 
-#if defined(USING_VMA_EXTRA_API) || defined(USING_XLIO_EXTRA_API)
+#ifdef USING_EXTRA_API
 #ifdef ST_TEST
     if (!stTest)
 #endif
@@ -3066,7 +3066,7 @@ int prepare_socket(int fd, struct fds_data *p_data)
             g_zeroCopyData[fd] = new ZeroCopyData();
             g_zeroCopyData[fd]->allocate();
         }
-#endif // USING_VMA_EXTRA_API || USING_XLIO_EXTRA_API
+#endif // USING_EXTRA_API
 
     return (!rc ? fd
                 : (int)INVALID_SOCKET); // TODO: use SOCKET all over the way and avoid this cast
@@ -3504,7 +3504,7 @@ int bringup(const int *p_daemonize) {
     /* Setup VMA */
     int _vma_pkts_desc_size = 0;
 
-#if defined(USING_VMA_EXTRA_API) || defined(USING_XLIO_EXTRA_API)
+#ifdef USING_EXTRA_API
     if (!rc && (s_user_params.is_rxfiltercb || s_user_params.is_zcopyread ||
                 s_user_params.fd_handler_type == SOCKETXTREME)) {
         // Get VMA extended API
@@ -3552,7 +3552,7 @@ int bringup(const int *p_daemonize) {
         errno = EPERM;
         exit_with_err("Please compile with VMA or XLIO Extra API to use these options", SOCKPERF_ERR_FATAL);
     }
-#endif // USING_VMA_EXTRA_API || USING_XLIO_EXTRA_API
+#endif // USING_EXTRA_API
 
 
 #if defined(DEFINED_TLS)

--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -96,7 +96,6 @@
 #include "message_parser.h"
 #include "packet.h"
 #include "port_descriptor.h"
-#include "switches.h"
 #include "aopt.h"
 #include <stdio.h>
 #include <sys/stat.h>
@@ -2670,13 +2669,6 @@ inline bool CallbackMessageHandler<T>::handle_message()
         }*/
         msgReply->setHeaderToHost();
     }
-    /*
-     * TODO
-     * To support other server functionality when using zero callback,
-     * pass the server as user_context or as we pass the replyMsg, and call the server functions
-     */
-    // m_switchCalcGaps.execute(vma_info->src, msgReply->getSequenceCounter(), false);
-    // m_switchActivityInfo.execute(g_receiveCount);
 
     return true;
 }


### PR DESCRIPTION
1. Adding support for XLIO socketxtreme and callback-api.
2.1 Includes support for multithreading with socketxtreme
3. Moving generally unused options from template parameter to unlikely if condition. These options are not for performance anyway.
2.1 Reduced binary size from 200GB to 32GB
2.2 Reduced compilation time significantly.
2.3 No performance impact was observed
4. Adding warnings for incompatible options