### PR TITLE
README: add BSD example dependency install

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ Specifically, in addition to the standard throughput tests, **sockperf** does th
      * Clang
      * icc
 
-   `sudo apt install perl make automake autoconf m4 libtool-bin g++`
+   Linux (Debian/Ubuntu): `sudo apt install perl make automake autoconf m4 libtool-bin g++`
+   
+   FreeBSD: `sudo pkg install gmake automake libtool`
 
 ## How to install
 


### PR DESCRIPTION
Update README to include an example dependency install for FreeBSD.

Accounts for some packaging details:
- freebsd >= 10 ships with clang, g++ not required.
- pkg install automake includes it's dependencies (including perl5 and m4)
- make is either bmake or gmake, either works with clang (cc on FreeBSD)
