### PR TITLE
[CI] BUGFIX - Blackduck test failing

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -2,7 +2,7 @@
 
 // load pipeline functions
 // Requires pipeline-github-lib plugin to load library from github
-@Library('github.com/Mellanox/ci-demo@stable')
+@Library('github.com/Mellanox/ci-demo@stable_media')
 def matrix = new com.mellanox.cicd.Matrix()
 
 matrix.main()

--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -7,7 +7,7 @@ registry_host: harbor.mellanox.com
 registry_auth: swx-storage
 
 kubernetes:
-  privileged: false
+  privileged: true
   cloud: swx-k8s-spray
   nodeSelector: 'beta.kubernetes.io/os=linux'
 
@@ -97,8 +97,6 @@ steps:
       ./.ci/artifacts.sh
     archiveArtifacts-onfail: |
       jenkins/**/arch-*.tar.gz
-    archiveTap-onfail: |
-      jenkins/**/*.tap
 
   - name: Package
     enable: ${do_package}
@@ -114,8 +112,6 @@ steps:
       ./.ci/artifacts.sh
     archiveArtifacts-onfail: |
       jenkins/**/arch-*.tar.gz
-    archiveTap-onfail: |
-      jenkins/**/*.tap
 
   - name: Style
     enable: ${do_style}
@@ -131,8 +127,6 @@ steps:
       ./.ci/artifacts.sh
     archiveArtifacts-onfail: |
       jenkins/**/arch-*.tar.gz
-    archiveTap-onfail: |
-      jenkins/**/*.tap
 
   - name: Compiler
     enable: ${do_compiler}
@@ -148,8 +142,6 @@ steps:
       ./.ci/artifacts.sh
     archiveArtifacts-onfail: |
       jenkins/**/arch-*.tar.gz
-    archiveTap-onfail: |
-      jenkins/**/*.tap
 
   - name: Coverity
     enable: ${do_coverity}
@@ -166,8 +158,6 @@ steps:
     archiveArtifacts-onfail: |
       jenkins/**/arch-*.tar.gz,
       jenkins/**/output/errors/**/*.html
-    archiveTap-onfail: |
-      jenkins/**/*.tap
 
   - name: Cppcheck
     enable: ${do_cppcheck}
@@ -183,8 +173,6 @@ steps:
       ./.ci/artifacts.sh
     archiveArtifacts-onfail: |
       jenkins/**/arch-*.tar.gz
-    archiveTap-onfail: |
-      jenkins/**/*.tap
 
   - name: Csbuild
     enable: ${do_csbuild}
@@ -200,8 +188,6 @@ steps:
       ./.ci/artifacts.sh
     archiveArtifacts-onfail: |
       jenkins/**/arch-*.tar.gz
-    archiveTap-onfail: |
-      jenkins/**/*.tap
 
   - name: Gtest
     enable: ${do_gtest}
@@ -217,8 +203,6 @@ steps:
       ./.ci/artifacts.sh
     archiveArtifacts-onfail: |
       jenkins/**/arch-*.tar.gz
-    archiveTap-onfail: |
-      jenkins/**/*.tap
     archiveJunit-onfail: |
       jenkins/**/*.xml
 
@@ -236,8 +220,6 @@ steps:
       ./.ci/artifacts.sh
     archiveArtifacts-onfail: |
       jenkins/**/arch-*.tar.gz
-    archiveTap-onfail: |
-      jenkins/**/*.tap
 
   - name: Artifacts
     enable: ${do_artifact}
@@ -246,8 +228,6 @@ steps:
     parallel: false
     archiveArtifacts: |
       jenkins/**/arch-*.tar.gz
-    archiveTap: |
-      jenkins/**/*.tap
     archiveJunit: |
       jenkins/**/*.xml
 
@@ -267,6 +247,8 @@ steps:
       attachArtifact: true
       reportName: "BlackDuck report"
       scanMode: "source"
+      skipDockerDaemonCheck: true
+      credentialsId: "b68aedbd-e39f-4ee2-acce-e25a5b91fe18"
     env:
       SPRING_APPLICATION_JSON: '{"blackduck.url":"https://blackduck.mellanox.com/","blackduck.api.token":"ODMwOWYwMzEtODA2ZC00MzBjLWI1ZDEtNmFiMjBkYzQzMzkwOjNmNjExN2M1LWE2ZmEtNDZlYS1hZjRiLTZlNDgwNjAwOTVjNw=="}'
 


### PR DESCRIPTION
Gerrit server was moved to a new url, and now enforces pulls with ssh/HTTP token instead of user/password
Blackduck test is failing due to trying to reach the old Gerrit server
Changes were made in this PR: https://github.com/Mellanox/ci-demo/pull/90 were made in order the resolve the issue

Change ci-demo library tag to the new tag created stable-media, which includes the use of the new ngci that connects to currect Gerrit URL
Add CredentialsId to provide username and HTTP token to pull blackduck from Gerrit
Remove TAP logic that was suppose to be removed due to the migration to Blossom

Issue: HPCINFRA-2289