### PR TITLE
[CI] Header check: upgrade version to NGCI v5.0.3-82

### DIFF
--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -14,6 +14,9 @@ kubernetes:
   limits: '{memory: 8Gi, cpu: 7000m}'
   requests: '{memory: 8Gi, cpu: 7000m}'
 
+credentials:
+  - {credentialsId: 'mellanox_github_credentials', usernameVariable: 'MELLANOX_GH_USER', passwordVariable: 'MELLANOX_GH_TOKEN'}
+
 volumes:
   - {mountPath: /hpc/local/bin, hostPath: /hpc/local/bin}
   - {mountPath: /hpc/local/oss, hostPath: /hpc/local/oss}
@@ -34,7 +37,7 @@ runs_on_dockers:
   - {name: 'fc31-mofed-x86_64',     url: 'harbor.mellanox.com/swx-infra/x86_64/fedora31/builder:mofed-5.1-1.0.7.0', category: 'base', arch: 'x86_64'}
   - {name: 'toolbox', url: 'harbor.mellanox.com/hpcx/x86_64/rhel8.3/builder:inbox', category: 'tool', arch: 'x86_64'}
   - {name: 'blackduck', url: 'harbor.mellanox.com/toolbox/ngci-centos:7.9.2009.2', category: 'tool', arch: 'x86_64'}
-  - {name: 'header-check', url: 'harbor.mellanox.com/toolbox/header_check:0.0.15', category: 'tool', arch: 'x86_64', tag: '0.0.15'}
+  - {name: 'header-check', url: 'harbor.mellanox.com/toolbox/header_check:0.0.51', category: 'tool', arch: 'x86_64', tag: '0.0.51'}
 
 runs_on_agents:
   - {nodeLabel: 'beni09', category: 'base'}
@@ -69,8 +72,9 @@ steps:
 
   - name: Copyrights
     enable: ${do_copyrights}
+    credentialsId: 'mellanox_github_credentials'
     run: |
-      env WORKSPACE=$PWD ./contrib/jenkins_tests/copyrights.sh
+      env WORKSPACE=$PWD GITHUB_TOKEN=$MELLANOX_GH_TOKEN ./contrib/jenkins_tests/copyrights.sh
     containerSelector:
       - "{name: 'header-check', category: 'tool', variant: 1}"
     agentSelector:

--- a/contrib/jenkins_tests/copyright-check-map.yaml
+++ b/contrib/jenkins_tests/copyright-check-map.yaml
@@ -38,7 +38,7 @@ general:
         - ".*avner-test-orig"
         - ".*\\.m4"
 
-nbu-open-source:
+dual_gpl_2_bsd_3:
     include:
         - ".*"
     exclude:

--- a/src/aopt.cpp
+++ b/src/aopt.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2011-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * All rights reserved.
  *

--- a/src/aopt.h
+++ b/src/aopt.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2011-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * All rights reserved.
  *

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2011-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * All rights reserved.
  *

--- a/src/client.h
+++ b/src/client.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2011-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * All rights reserved.
  *

--- a/src/clock.h
+++ b/src/clock.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2011-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * All rights reserved.
  *

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2011-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * All rights reserved.
  *

--- a/src/common.h
+++ b/src/common.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2011-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * All rights reserved.
  *

--- a/src/defs.cpp
+++ b/src/defs.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2011-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * All rights reserved.
  *

--- a/src/defs.h
+++ b/src/defs.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2011-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * All rights reserved.
  *

--- a/src/input_handlers.h
+++ b/src/input_handlers.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * All rights reserved.
  *

--- a/src/iohandlers.cpp
+++ b/src/iohandlers.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2011-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * All rights reserved.
  *

--- a/src/iohandlers.h
+++ b/src/iohandlers.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2011-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * All rights reserved.
  *

--- a/src/ip_address.cpp
+++ b/src/ip_address.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2021-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * All rights reserved.
  *

--- a/src/ip_address.h
+++ b/src/ip_address.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2021-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * All rights reserved.
  *

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2011-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * All rights reserved.
  *

--- a/src/message.h
+++ b/src/message.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2011-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * All rights reserved.
  *

--- a/src/message_parser.h
+++ b/src/message_parser.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * All rights reserved.
  *

--- a/src/os_abstract.cpp
+++ b/src/os_abstract.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2011-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * All rights reserved.
  *

--- a/src/os_abstract.h
+++ b/src/os_abstract.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2011-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * All rights reserved.
  *

--- a/src/packet.cpp
+++ b/src/packet.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2011-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * All rights reserved.
  *

--- a/src/packet.h
+++ b/src/packet.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2011-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * All rights reserved.
  *

--- a/src/playback.cpp
+++ b/src/playback.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2011-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * All rights reserved.
  *

--- a/src/playback.h
+++ b/src/playback.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2011-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * All rights reserved.
  *

--- a/src/port_descriptor.h
+++ b/src/port_descriptor.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2021-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * All rights reserved.
  *

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2011-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * All rights reserved.
  *

--- a/src/server.h
+++ b/src/server.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2011-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * All rights reserved.
  *

--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2011-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * All rights reserved.
  *

--- a/src/switches.h
+++ b/src/switches.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2011-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * All rights reserved.
  *

--- a/src/ticks.cpp
+++ b/src/ticks.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2011-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * All rights reserved.
  *

--- a/src/ticks.h
+++ b/src/ticks.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2011-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * All rights reserved.
  *

--- a/src/ticks_os.h
+++ b/src/ticks_os.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2011-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * All rights reserved.
  *

--- a/src/tls.cpp
+++ b/src/tls.cpp
@@ -1,5 +1,6 @@
 /*
  *
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2021-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * All rights reserved.
  *

--- a/src/tls.h
+++ b/src/tls.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2021-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * All rights reserved.
  *

--- a/src/vma-xlio-redirect.cpp
+++ b/src/vma-xlio-redirect.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2011-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * All rights reserved.
  *

--- a/src/vma-xlio-redirect.h
+++ b/src/vma-xlio-redirect.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2011-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * All rights reserved.
  *

--- a/tests/avner-master-test.sh
+++ b/tests/avner-master-test.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 #
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
 # Copyright (c) 2011-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # All rights reserved.
 #

--- a/tests/avner-test.sh
+++ b/tests/avner-test.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 #
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
 # Copyright (c) 2011-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # All rights reserved.
 #

--- a/tests/gtest/main.cpp
+++ b/tests/gtest/main.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * All rights reserved.
  *

--- a/tests/gtest/message_parser_tests.cpp
+++ b/tests/gtest/message_parser_tests.cpp
@@ -1,4 +1,5 @@
 /*
+ * SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
  * Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * All rights reserved.
  *

--- a/tests/verifier/verifier.pl
+++ b/tests/verifier/verifier.pl
@@ -1,5 +1,6 @@
 #!/usr/bin/env perl
 #
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
 # Copyright (c) 2011-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # All rights reserved.
 #

--- a/tests/vma_multiplexers_test.sh
+++ b/tests/vma_multiplexers_test.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
 # Copyright (c) 2011-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # All rights reserved.
 #

--- a/tests/vma_perf_envelope.sh
+++ b/tests/vma_perf_envelope.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
 # Copyright (c) 2011-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # All rights reserved.
 #


### PR DESCRIPTION
We're requested to upgrade the header checker tool (Copyright check tool) to latest version.

Issue: HPCINFRA-2612