### PR TITLE
[CI]: fixing false positives in the Secrets Scanner

### DIFF
--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -248,7 +248,7 @@ steps:
       reportName: "BlackDuck report"
       scanMode: "source"
       skipDockerDaemonCheck: true
-      credentialsId: "b68aedbd-e39f-4ee2-acce-e25a5b91fe18"
+      credentialsId: "swx-jenkins3-svc_git-nbu_token"
     env:
       SPRING_APPLICATION_JSON: '{"blackduck.url":"https://blackduck.mellanox.com/","blackduck.api.token":"ODMwOWYwMzEtODA2ZC00MzBjLWI1ZDEtNmFiMjBkYzQzMzkwOjNmNjExN2M1LWE2ZmEtNDZlYS1hZjRiLTZlNDgwNjAwOTVjNw=="}'
 

--- a/.ci/proj_jjb.yaml
+++ b/.ci/proj_jjb.yaml
@@ -88,7 +88,7 @@
             failure-status: "[FAIL]"
             error-status:   "[FAIL]"
             status-add-test-results: true
-            auth-id: '2806c206-c725-4d8c-af4b-bedfc463b401'
+            auth-id: 'swx-jenkins5_gh_token'
             org-list: ["Mellanox"]
             white-list: ["swx-jenkins","swx-jenkins2","swx-jenkins3","mellanox-github"]
             allow-whitelist-orgs-as-admins: true
@@ -97,7 +97,7 @@
         scm:
             - git:
                 url: "{jjb_git}"
-                credentials-id: 'b7d08ca7-378c-45d6-ac4b-3f30bdf49168'
+                credentials-id: 'swx-jenkins_ssh_key'
                 branches: ['$sha1']
                 shallow-clone: true
                 depth: 2

--- a/.ci/windows/windows_proj_jjb.yaml
+++ b/.ci/windows/windows_proj_jjb.yaml
@@ -33,8 +33,8 @@
             failure-status: "[FAIL]"
             error-status:   "[FAIL]"
             status-add-test-results: true
-            # swx-jenkins2 from GitHub Pull Request Builder
-            auth-id: '2806c206-c725-4d8c-af4b-bedfc463b401'
+            # swx-jenkins5 from GitHub Pull Request Builder
+            auth-id: 'swx-jenkins5_gh_token'
             org-list: ["Mellanox", "mellanox-hpc", "Mellanox-lab"]
             allow-whitelist-orgs-as-admins: true
             cancel-builds-on-update: true
@@ -55,7 +55,7 @@
         - git:
             url: "{jjb_git}"
             # swx-jenkins3 GH user/pass
-            credentials-id: 'b7d08ca7-378c-45d6-ac4b-3f30bdf49168'
+            credentials-id: 'swx-jenkins_ssh_key'
             branches: ['$sha1']
             shallow-clone: true
             depth: 10


### PR DESCRIPTION
We need to rename Jenkins secrets IDs to human readable form.

Jenkins secrets we reference in the CI are currently represented in UUID format. It confuses Secrets Scanner, which takes these data for passwords.

Renaming these secret IDs in Jenkins will allow us to restor Secrets Scanner normal workflow.

issue: HPCINFRA-2689