### PR TITLE
fix compile error on freebsd

### DIFF
--- a/src/ip_address.h
+++ b/src/ip_address.h
@@ -43,7 +43,7 @@ typedef unsigned short int sa_family_t;
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <sys/un.h>      /* definitions for UNIX domain sockets */
-
+#include <cstring>
 #endif // defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)
 
 #include "os_abstract.h"


### PR DESCRIPTION
Fix compile error

```
depbase=`echo src/ip_address.o | sed 's|[^/]*$|.deps/&|;s|\.o$||'`; g++ -DHAVE_CONFIG_H -I.   -imacros ./config.h  -Wall --param inline-unit-growth=300 -O3 -g -MT src/ip_address.o -MD -MP -MF $depbase.Tpo -c -o src                                                                /ip_address.o src/ip_address.cpp && mv -f $depbase.Tpo $depbase.Po
In file included from /usr/include/netinet/in.h:703,
                 from src/ip_address.h:44,
                 from src/ip_address.cpp:30:
src/ip_address.h: In function 'bool operator==(const IPAddress&, const IPAddress&)':
src/ip_address.h:107:24: error: 'memcmp' was not declared in this scope
  107 |                 return IN6_ARE_ADDR_EQUAL(&key1.m_addr6, &key2.m_addr6);
      |                        ^~~~~~~~~~~~~~~~~~
src/ip_address.h:52:1: note: 'memcmp' is defined in header '<cstring>'; did you forget to '#include <cstring>'?
```