### PR TITLE
[CI] Update GHPRB service user

### DIFF
--- a/.ci/proj_jjb.yaml
+++ b/.ci/proj_jjb.yaml
@@ -88,7 +88,8 @@
             failure-status: "[FAIL]"
             error-status:   "[FAIL]"
             status-add-test-results: true
-            auth-id: 'swx-jenkins5_gh_token'
+            # svc-nbu-swx-media from GitHub Pull Request Builder
+            auth-id: 'svc-nbu-swx-media_GHPRB_ID'
             org-list: ["Mellanox"]
             white-list: ["swx-jenkins","swx-jenkins2","swx-jenkins3","mellanox-github"]
             allow-whitelist-orgs-as-admins: true

--- a/.ci/windows/windows_proj_jjb.yaml
+++ b/.ci/windows/windows_proj_jjb.yaml
@@ -33,8 +33,8 @@
             failure-status: "[FAIL]"
             error-status:   "[FAIL]"
             status-add-test-results: true
-            # swx-jenkins5 from GitHub Pull Request Builder
-            auth-id: 'swx-jenkins5_gh_token'
+            # svc-nbu-swx-media from GitHub Pull Request Builder
+            auth-id: 'svc-nbu-swx-media_GHPRB_ID'
             org-list: ["Mellanox", "mellanox-hpc", "Mellanox-lab"]
             allow-whitelist-orgs-as-admins: true
             cancel-builds-on-update: true


### PR DESCRIPTION
Shared user sometimes been abused by other teams causing GitHub token exhaustion
This causes delays in GHPRB plug in response

Move to media team dedicated service user

Issue: HPCINFRA-3443