### PR TITLE
[CI] BlackDuck scan startup fix

### DIFF
--- a/.ci/blackduck_source.sh
+++ b/.ci/blackduck_source.sh
@@ -1,0 +1,47 @@
+#!/bin/bash -Exel
+
+# Check if the variables and pipeline attributes are set
+[[ -z "${WORKSPACE}" ]] && { echo "Error: WORKSPACE variable is not set"; exit 1; }
+[[ -z "$BLACKDUCK_API_TOKEN" ]] && { echo "Error: BLACKDUCK_API_TOKEN variable is not set"; exit 1; }
+[[ ! -d "${WORKSPACE}/logs" ]] && mkdir -p "${WORKSPACE}/logs"
+
+# Create valid JSON for further authentication in BlackDuck server
+json=$(jq -n \
+  --arg token "${BLACKDUCK_API_TOKEN}" \
+  '{"blackduck.url": "https://blackduck.mellanox.com/", "blackduck.api.token": $token }')
+
+export SPRING_APPLICATION_JSON="${json}"
+export PROJECT_NAME=LibVMA
+export PROJECT_VERSION="${sha1}"
+export PROJECT_SRC_PATH="${WORKSPACE}"/src/
+
+echo "Running BlackDuck (SRC) on ${name}"
+echo "CONFIG:"
+echo "        NAME: ${PROJECT_NAME}"
+echo "     VERSION: ${PROJECT_VERSION}"
+echo "    SRC_PATH: ${PROJECT_SRC_PATH}"
+
+# clone BlackDuck
+[[ -d /tmp/blackduck ]] && rm -rf /tmp/blackduck
+chmod 600 "${GERRIT_SSH_KEY}"
+SSH_CMD="ssh -i ${GERRIT_SSH_KEY} -l swx-jenkins2-svc -o StrictHostKeyChecking=no"
+git clone -c core.sshCommand="${SSH_CMD}" -b master --single-branch --depth=1 ssh://git-nbu.nvidia.com:12023/DevOps/Tools/blackduck /tmp/blackduck
+cd /tmp/blackduck
+
+# disable check errors
+set +e
+timeout 3600 ./run_bd_scan.sh
+exit_code=$?
+# enable back
+set -e
+
+# copy run log to a place that jenkins job will archive it
+REPORT_NAME="BlackDuck_source_${PROJECT_NAME}_${PROJECT_VERSION}"
+cat "log/${PROJECT_NAME}_${PROJECT_VERSION}"*.log > "${WORKSPACE}/logs/${REPORT_NAME}.log" || true
+cat "log/${PROJECT_NAME}_${PROJECT_VERSION}"*.log || true
+
+if [ "${exit_code}" == "0" ]; then
+    cp -v /tmp/blackduck/report/*.pdf "${WORKSPACE}/logs/${REPORT_NAME}.pdf"
+fi
+
+exit "${exit_code}"

--- a/.ci/dockerfiles/Dockerfile.rhel8.6
+++ b/.ci/dockerfiles/Dockerfile.rhel8.6
@@ -1,0 +1,18 @@
+ARG HARBOR_URL=nbu-harbor.gtm.nvidia.com
+ARG ARCH=x86_64
+FROM $HARBOR_URL/hpcx/x86_64/rhel8.6/core:latest
+ARG WEBREPO_URL=webrepo.gtm.nvidia.com
+
+RUN sed -i "s/webrepo/${WEBREPO_URL}/" /etc/yum.repos.d/* && \
+    sed -i 's/mirrorlist/#mirrorlist/;s!#baseurl=http://mirror.centos.org!baseurl=http://vault.centos.org!' /etc/yum.repos.d/* && \
+    echo "[mlnx-opt]" > /etc/yum.repos.d/mlnx-opt.repo && \
+    echo "name=RHEL 8.6 mirror" >> /etc/yum.repos.d/mlnx-opt.repo && \
+    echo "baseurl=http://${WEBREPO_URL}/RH/optional/8.6/x86_64/" >> /etc/yum.repos.d/mlnx-opt.repo && \
+    echo "enabled=1" >> /etc/yum.repos.d/mlnx-opt.repo && \
+    echo "gpgcheck=0" >> /etc/yum.repos.d/mlnx-opt.repo && \
+    yum makecache
+
+RUN yum install --allowerasing -y \
+    java-11-openjdk jq git && \
+    yum clean all && \
+    rm -rf /var/cache/yum    

--- a/.ci/matrix_job.yaml
+++ b/.ci/matrix_job.yaml
@@ -17,6 +17,8 @@ kubernetes:
 
 credentials:
   - {credentialsId: 'mellanox_github_credentials', usernameVariable: 'MELLANOX_GH_USER', passwordVariable: 'MELLANOX_GH_TOKEN'}
+  - {credentialsId: 'swx-jenkins2-svc-gerrit-ssh-key', keyFileVariable: 'GERRIT_SSH_KEY', type: 'sshUserPrivateKey'}
+  - {credentialsId: 'blackduck_api_token', type: 'string', variable: 'BLACKDUCK_API_TOKEN'}
 
 volumes:
   - {mountPath: /hpc/local/bin, hostPath: /hpc/local/bin}
@@ -37,7 +39,7 @@ runs_on_dockers:
   - {name: 'sl15sp2-mofed-x86_64',  url: 'harbor.mellanox.com/swx-infra/x86_64/sles15sp2/builder:mofed-5.2-2.2.0.0', category: 'base', arch: 'x86_64'}
   - {name: 'fc31-mofed-x86_64',     url: 'harbor.mellanox.com/swx-infra/x86_64/fedora31/builder:mofed-5.1-1.0.7.0', category: 'base', arch: 'x86_64'}
   - {name: 'toolbox', url: 'harbor.mellanox.com/hpcx/x86_64/rhel8.3/builder:inbox', category: 'tool', arch: 'x86_64'}
-  - {name: 'blackduck', url: 'harbor.mellanox.com/toolbox/ngci-centos:7.9.2009.2', category: 'tool', arch: 'x86_64'}
+  - {name: 'blackduck', file: '.ci/dockerfiles/Dockerfile.rhel8.6', category: 'tool', arch: 'x86_64', tag: '20250422', uri: 'sockperf/$arch/$name/bduck', build_args: '--no-cache'}
   - {name: 'header-check', url: 'harbor.mellanox.com/toolbox/header_check:0.0.51', category: 'tool', arch: 'x86_64', tag: '0.0.51'}
 
 runs_on_agents:
@@ -242,20 +244,15 @@ steps:
       - "{name: 'blackduck', category:'tool', variant:1}"
     agentSelector:
       - "{nodeLabel: 'skip-agent'}"
-    shell: action
-    module: ngci
-    run: NGCIBlackDuckScan
-    args:
-      projectName: "sockperf"
-      projectVersion: "0.1.0"
-      projectSrcPath: "src"
-      attachArtifact: true
-      reportName: "BlackDuck report"
-      scanMode: "source"
-      skipDockerDaemonCheck: true
-      credentialsId: "swx-jenkins3-svc_git-nbu_token"
-    env:
-      SPRING_APPLICATION_JSON: '{"blackduck.url":"https://blackduck.mellanox.com/","blackduck.api.token":"ODMwOWYwMzEtODA2ZC00MzBjLWI1ZDEtNmFiMjBkYzQzMzkwOjNmNjExN2M1LWE2ZmEtNDZlYS1hZjRiLTZlNDgwNjAwOTVjNw=="}'
+    run: |
+      # WA for possible CI-Demo bug: HPCINFRA-1614
+      if ${do_blackduck} ; then
+        .ci/blackduck_source.sh
+      fi
+    archiveArtifacts: 'logs/'
+    credentialsId: 
+      - "swx-jenkins2-svc-gerrit-ssh-key"
+      - "blackduck_api_token"
 
 pipeline_start:
   run: |
@@ -268,6 +265,6 @@ pipeline_stop:
 
 failFast: false
 
-timeout_minutes: 180
+timeout_minutes: 150
 
 taskName: '${flags}/${name}/${axis_index}'


### PR DESCRIPTION
This change removes the NGCI module previously used for running BlackDuck scans. NGCI relied on a Gerrit user token for cloning BlackDuck, which was subject to periodic rotation and caused recurring CI failures. Instead, the scan is now executed via a custom script using an SSH-based access to Gerrit. This approach improves reliability, simplifies debugging, and provides clearer logs.

Issue: HPCINFRA-3508