### PR TITLE
Add optional reply-size argument

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -690,6 +690,7 @@ ClientBase::ClientBase() {
     m_pMsgRequest = new Message();
     m_pMsgRequest->getHeader()->setClient();
     m_pMsgRequest->setLength(g_pApp->m_const_params.msg_size);
+    m_pMsgRequest->setReplySize(g_pApp->m_const_params.reply_size);
 }
 
 //------------------------------------------------------------------------------

--- a/src/defs.h
+++ b/src/defs.h
@@ -162,6 +162,7 @@ typedef unsigned short int sa_family_t;
 extern int MAX_PAYLOAD_SIZE;
 extern int max_fds_num;
 #define MAX_TCP_SIZE ((1 << 20) - 1)
+#define MAX_PAYLOAD_SIZE_LIMIT 65507
 
 const uint32_t MPS_MAX_UL =
     10 * 1000 * 1000; //  10 M MPS is 4 times the maximum possible under VMA today

--- a/src/defs.h
+++ b/src/defs.h
@@ -291,6 +291,7 @@ enum {
     OPT_HISTOGRAM,                // 46
     OPT_LOAD_XLIO,                // 47
     OPT_TCP_NB_CONN_TIMEOUT_MS,   // 48
+    OPT_REPLY_SIZE,               // 49
 #if defined(DEFINED_TLS)
     OPT_TLS
 #endif /* DEFINED_TLS */
@@ -733,6 +734,7 @@ struct user_params_t {
     IPAddress tx_mc_if_addr;
     IPAddress mc_source_ip_addr;
     int msg_size = MIN_PAYLOAD_SIZE;
+    int reply_size = 0;
     int msg_size_range = 0;
     int sec_test_duration = DEFAULT_TEST_DURATION;
     uint64_t number_test_target = DEFAULT_TEST_NUMBER;

--- a/src/message.h
+++ b/src/message.h
@@ -67,16 +67,18 @@ public:
         m_sequence_number = htonll(m_sequence_number);
         m_flags_and_length.m_flags = htons(m_flags_and_length.m_flags);
         m_flags_and_length.length = htonl(m_flags_and_length.length);
+        m_reply_size = htonl(m_reply_size);
     }
 
     void ntoh() {
         m_sequence_number = ntohll(m_sequence_number);
         m_flags_and_length.m_flags = ntohs(m_flags_and_length.m_flags);
         m_flags_and_length.length = ntohl(m_flags_and_length.length);
+        m_reply_size = ntohl(m_reply_size);
     }
     // this is different than sizeof(MsgHeader) and safe only for the current implementation of the
     // class
-    static const int EFFECTIVE_SIZE = (int)(sizeof(uint64_t) + sizeof(uint16_t) + sizeof(uint32_t));
+    static const int EFFECTIVE_SIZE = (int)(sizeof(uint64_t) + sizeof(uint16_t) + sizeof(uint32_t) + sizeof(uint32_t));
     //	static const int EFFECTIVE_SIZE = 16;
 
 private:
@@ -90,6 +92,7 @@ private:
     // pack() pragma can be added to set needed alignment
     uint64_t m_sequence_number;
     s_flags_and_length m_flags_and_length;
+    uint32_t m_reply_size = 0;
 
     static const uint32_t MASK_CLIENT = 1;
     static const uint32_t MASK_PONG = 2;
@@ -171,6 +174,9 @@ public:
         return m_header->m_flags_and_length.length;
     }
     void setLength(uint32_t _length) { m_header->m_flags_and_length.length = _length; }
+
+    uint32_t getReplySize() const { return m_header->m_reply_size; }
+    void setReplySize(uint32_t _reply_size) { m_header->m_reply_size = _reply_size; }
 
     bool isValidHeader() const
     {

--- a/src/server.h
+++ b/src/server.h
@@ -360,7 +360,7 @@ inline bool Server<IoType, SwitchCalcGaps>::handle_message(int ifd,
             /* always send to the same port recved from */
             sockaddr_set_portn(sendto_addr, sockaddr_get_portn(recvfrom_addr));
         }
-        int length = m_pMsgReply->getLength();
+        int length = m_pMsgReply->getReplySize() ? m_pMsgReply->getReplySize() : m_pMsgReply->getLength();
         m_pMsgReply->setHeaderToNetwork();
 
         int ret = msg_sendto(ifd, m_pMsgReply->getBuf(), length,

--- a/src/server.h
+++ b/src/server.h
@@ -360,7 +360,9 @@ inline bool Server<IoType, SwitchCalcGaps>::handle_message(int ifd,
             /* always send to the same port recved from */
             sockaddr_set_portn(sendto_addr, sockaddr_get_portn(recvfrom_addr));
         }
-        int length = m_pMsgReply->getReplySize() ? m_pMsgReply->getReplySize() : m_pMsgReply->getLength();
+        const int request_length = m_pMsgReply->getLength();
+        int length = m_pMsgReply->getReplySize() ? m_pMsgReply->getReplySize() : request_length;
+        m_pMsgReply->setLength(length);
         m_pMsgReply->setHeaderToNetwork();
 
         int ret = msg_sendto(ifd, m_pMsgReply->getBuf(), length,
@@ -372,6 +374,7 @@ inline bool Server<IoType, SwitchCalcGaps>::handle_message(int ifd,
             return false;
         }
         m_pMsgReply->setHeaderToHost();
+        m_pMsgReply->setLength(request_length);
     }
 
     m_switchCalcGaps.execute(recvfrom_addr, recvfrom_len, m_pMsgReply->getSequenceCounter(), false);

--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -636,9 +636,9 @@ static int proc_mode_under_load(int id, int argc, const char **argv) {
                     log_msg("'--reply-size' Invalid reply size: %s (min: %d)", optarg,
                             MIN_PAYLOAD_SIZE);
                     rc = SOCKPERF_ERR_BAD_ARGUMENT;
-                } else if (!aopt_check(common_obj, OPT_TCP) && value > MAX_PAYLOAD_SIZE) {
+                } else if (!aopt_check(common_obj, OPT_TCP) && value > MAX_PAYLOAD_SIZE_LIMIT) {
                     log_msg("'--reply-size' Invalid reply size: %s (max: %d)", optarg,
-                            MAX_PAYLOAD_SIZE);
+                            MAX_PAYLOAD_SIZE_LIMIT);
                     rc = SOCKPERF_ERR_BAD_ARGUMENT;
                 } else if (aopt_check(common_obj, OPT_TCP) && value > MAX_TCP_SIZE) {
                     log_msg("'--reply-size' Invalid reply size: %s (max: %d)", optarg, MAX_TCP_SIZE);
@@ -988,9 +988,9 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
                     log_msg("'--reply-size' Invalid reply size: %s (min: %d)", optarg,
                             MIN_PAYLOAD_SIZE);
                     rc = SOCKPERF_ERR_BAD_ARGUMENT;
-                } else if (!aopt_check(common_obj, OPT_TCP) && value > MAX_PAYLOAD_SIZE) {
+                } else if (!aopt_check(common_obj, OPT_TCP) && value > MAX_PAYLOAD_SIZE_LIMIT) {
                     log_msg("'--reply-size' Invalid reply size: %s (max: %d)", optarg,
-                            MAX_PAYLOAD_SIZE);
+                            MAX_PAYLOAD_SIZE_LIMIT);
                     rc = SOCKPERF_ERR_BAD_ARGUMENT;
                 } else if (aopt_check(common_obj, OPT_TCP) && value > MAX_TCP_SIZE) {
                     log_msg("'--reply-size' Invalid reply size: %s (max: %d)", optarg, MAX_TCP_SIZE);
@@ -1308,9 +1308,9 @@ static int proc_mode_throughput(int id, int argc, const char **argv) {
                     log_msg("'--reply-size' Invalid reply size: %s (min: %d)", optarg,
                             MIN_PAYLOAD_SIZE);
                     rc = SOCKPERF_ERR_BAD_ARGUMENT;
-                } else if (!aopt_check(common_obj, OPT_TCP) && value > MAX_PAYLOAD_SIZE) {
+                } else if (!aopt_check(common_obj, OPT_TCP) && value > MAX_PAYLOAD_SIZE_LIMIT) {
                     log_msg("'--reply-size' Invalid reply size: %s (max: %d)", optarg,
-                            MAX_PAYLOAD_SIZE);
+                            MAX_PAYLOAD_SIZE_LIMIT);
                     rc = SOCKPERF_ERR_BAD_ARGUMENT;
                 } else if (aopt_check(common_obj, OPT_TCP) && value > MAX_TCP_SIZE) {
                     log_msg("'--reply-size' Invalid reply size: %s (max: %d)", optarg, MAX_TCP_SIZE);

--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -2765,7 +2765,13 @@ inline bool CallbackMessageHandler<T>::handle_message()
             sockaddr_set_portn(sendto_addr, sockaddr_get_portn((sockaddr_store_t &)*m_extra_info->src));
         }
         const int request_length = msgReply->getLength();
-        int length = msgReply->getReplySize() ? msgReply->getReplySize() : request_length;
+        // Validate reply_size from untrusted network header
+        uint32_t reply_size = msgReply->getReplySize();
+        int length = request_length;  // default to validated request length
+        if (reply_size > 0 && reply_size <= (uint32_t)Message::getMaxSize() && reply_size <= (uint32_t)request_length) {
+            // Use reply_size only if it's within buffer capacity and not exceeding request length
+            length = static_cast<int>(reply_size);
+        }
         msgReply->setLength(length);
         msgReply->setHeaderToNetwork();
         msg_sendto(m_fd, msgReply->getBuf(), length, reinterpret_cast<sockaddr *>(&sendto_addr), sendto_len);

--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -483,6 +483,9 @@ static int proc_mode_under_load(int id, int argc, const char **argv) {
           aopt_set_literal(0),
           aopt_set_string("histogram"),
           "Build histogram of latencies. Histogram arguments formated as binsize:lowerrange:upperrange " },
+        { OPT_REPLY_SIZE, AOPT_ARG, aopt_set_literal(0),
+          aopt_set_string("reply-size"),
+          "Set the server reply message size in bytes (default: same as -m)." },
         { 0, AOPT_NOARG, aopt_set_literal(0), aopt_set_string(NULL), NULL }
     };
 
@@ -620,6 +623,31 @@ static int proc_mode_under_load(int id, int argc, const char **argv) {
                 }
             } else {
                 log_msg("'-%c' Invalid value", 'm');
+                rc = SOCKPERF_ERR_BAD_ARGUMENT;
+            }
+        }
+
+        if (!rc && aopt_check(self_obj, OPT_REPLY_SIZE)) {
+            const char *optarg = aopt_value(self_obj, OPT_REPLY_SIZE);
+            if (optarg) {
+                errno = 0;
+                int value = strtol(optarg, NULL, 0);
+                if (errno != 0 || (value != 0 && value < MIN_PAYLOAD_SIZE)) {
+                    log_msg("'--reply-size' Invalid reply size: %s (min: %d)", optarg,
+                            MIN_PAYLOAD_SIZE);
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                } else if (!aopt_check(common_obj, OPT_TCP) && value > MAX_PAYLOAD_SIZE) {
+                    log_msg("'--reply-size' Invalid reply size: %s (max: %d)", optarg,
+                            MAX_PAYLOAD_SIZE);
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                } else if (aopt_check(common_obj, OPT_TCP) && value > MAX_TCP_SIZE) {
+                    log_msg("'--reply-size' Invalid reply size: %s (max: %d)", optarg, MAX_TCP_SIZE);
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                } else {
+                    s_user_params.reply_size = value;
+                }
+            } else {
+                log_msg("'--reply-size' Invalid value");
                 rc = SOCKPERF_ERR_BAD_ARGUMENT;
             }
         }
@@ -792,6 +820,9 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
           aopt_set_literal(0),
           aopt_set_string("histogram"),
           "Build histogram of latencies. Histogram arguments formated as binsize:lowerrange:upperrange " },
+        { OPT_REPLY_SIZE, AOPT_ARG, aopt_set_literal(0),
+          aopt_set_string("reply-size"),
+          "Set the server reply message size in bytes (default: same as -m)." },
         { 0, AOPT_NOARG, aopt_set_literal(0), aopt_set_string(NULL), NULL }
     };
 
@@ -943,6 +974,31 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
                 }
             } else {
                 log_msg("'-%c' Invalid value", 'm');
+                rc = SOCKPERF_ERR_BAD_ARGUMENT;
+            }
+        }
+
+        if (!rc && aopt_check(self_obj, OPT_REPLY_SIZE)) {
+            const char *optarg = aopt_value(self_obj, OPT_REPLY_SIZE);
+            if (optarg) {
+                errno = 0;
+                int value = strtol(optarg, NULL, 0);
+                if (errno != 0 || (value != 0 && value < MIN_PAYLOAD_SIZE)) {
+                    log_msg("'--reply-size' Invalid reply size: %s (min: %d)", optarg,
+                            MIN_PAYLOAD_SIZE);
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                } else if (!aopt_check(common_obj, OPT_TCP) && value > MAX_PAYLOAD_SIZE) {
+                    log_msg("'--reply-size' Invalid reply size: %s (max: %d)", optarg,
+                            MAX_PAYLOAD_SIZE);
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                } else if (aopt_check(common_obj, OPT_TCP) && value > MAX_TCP_SIZE) {
+                    log_msg("'--reply-size' Invalid reply size: %s (max: %d)", optarg, MAX_TCP_SIZE);
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                } else {
+                    s_user_params.reply_size = value;
+                }
+            } else {
+                log_msg("'--reply-size' Invalid value");
                 rc = SOCKPERF_ERR_BAD_ARGUMENT;
             }
         }
@@ -1113,6 +1169,9 @@ static int proc_mode_throughput(int id, int argc, const char **argv) {
           aopt_set_literal('r'),
           aopt_set_string("range"),
           "comes with -m <size>, randomly change the messages size in range: <size> +- <N>." },
+        { OPT_REPLY_SIZE, AOPT_ARG, aopt_set_literal(0),
+          aopt_set_string("reply-size"),
+          "Set the server reply message size in bytes (default: same as -m)." },
         { 0, AOPT_NOARG, aopt_set_literal(0), aopt_set_string(NULL), NULL }
     };
 
@@ -1234,6 +1293,31 @@ static int proc_mode_throughput(int id, int argc, const char **argv) {
                 }
             } else {
                 log_msg("'-%c' Invalid value", 'm');
+                rc = SOCKPERF_ERR_BAD_ARGUMENT;
+            }
+        }
+
+        if (!rc && aopt_check(self_obj, OPT_REPLY_SIZE)) {
+            const char *optarg = aopt_value(self_obj, OPT_REPLY_SIZE);
+            if (optarg) {
+                errno = 0;
+                int value = strtol(optarg, NULL, 0);
+                if (errno != 0 || (value != 0 && value < MIN_PAYLOAD_SIZE)) {
+                    log_msg("'--reply-size' Invalid reply size: %s (min: %d)", optarg,
+                            MIN_PAYLOAD_SIZE);
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                } else if (!aopt_check(common_obj, OPT_TCP) && value > MAX_PAYLOAD_SIZE) {
+                    log_msg("'--reply-size' Invalid reply size: %s (max: %d)", optarg,
+                            MAX_PAYLOAD_SIZE);
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                } else if (aopt_check(common_obj, OPT_TCP) && value > MAX_TCP_SIZE) {
+                    log_msg("'--reply-size' Invalid reply size: %s (max: %d)", optarg, MAX_TCP_SIZE);
+                    rc = SOCKPERF_ERR_BAD_ARGUMENT;
+                } else {
+                    s_user_params.reply_size = value;
+                }
+            } else {
+                log_msg("'--reply-size' Invalid value");
                 rc = SOCKPERF_ERR_BAD_ARGUMENT;
             }
         }
@@ -2677,7 +2761,7 @@ inline bool CallbackMessageHandler<T>::handle_message()
             /* always send to the same port recved from */
             sockaddr_set_portn(sendto_addr, sockaddr_get_portn((sockaddr_store_t &)*m_extra_info->src));
         }
-        int length = msgReply->getLength();
+        int length = msgReply->getReplySize() ? msgReply->getReplySize() : msgReply->getLength();
         msgReply->setHeaderToNetwork();
         msg_sendto(m_fd, msgReply->getBuf(), length, reinterpret_cast<sockaddr *>(&sendto_addr), sendto_len);
         /*if (ret == RET_SOCKET_SHUTDOWN) {

--- a/src/sockperf.cpp
+++ b/src/sockperf.cpp
@@ -644,6 +644,7 @@ static int proc_mode_under_load(int id, int argc, const char **argv) {
                     log_msg("'--reply-size' Invalid reply size: %s (max: %d)", optarg, MAX_TCP_SIZE);
                     rc = SOCKPERF_ERR_BAD_ARGUMENT;
                 } else {
+                    MAX_PAYLOAD_SIZE = _max(MAX_PAYLOAD_SIZE, value);
                     s_user_params.reply_size = value;
                 }
             } else {
@@ -995,6 +996,7 @@ static int proc_mode_ping_pong(int id, int argc, const char **argv) {
                     log_msg("'--reply-size' Invalid reply size: %s (max: %d)", optarg, MAX_TCP_SIZE);
                     rc = SOCKPERF_ERR_BAD_ARGUMENT;
                 } else {
+                    MAX_PAYLOAD_SIZE = _max(MAX_PAYLOAD_SIZE, value);
                     s_user_params.reply_size = value;
                 }
             } else {
@@ -1314,6 +1316,7 @@ static int proc_mode_throughput(int id, int argc, const char **argv) {
                     log_msg("'--reply-size' Invalid reply size: %s (max: %d)", optarg, MAX_TCP_SIZE);
                     rc = SOCKPERF_ERR_BAD_ARGUMENT;
                 } else {
+                    MAX_PAYLOAD_SIZE = _max(MAX_PAYLOAD_SIZE, value);
                     s_user_params.reply_size = value;
                 }
             } else {
@@ -2761,7 +2764,9 @@ inline bool CallbackMessageHandler<T>::handle_message()
             /* always send to the same port recved from */
             sockaddr_set_portn(sendto_addr, sockaddr_get_portn((sockaddr_store_t &)*m_extra_info->src));
         }
-        int length = msgReply->getReplySize() ? msgReply->getReplySize() : msgReply->getLength();
+        const int request_length = msgReply->getLength();
+        int length = msgReply->getReplySize() ? msgReply->getReplySize() : request_length;
+        msgReply->setLength(length);
         msgReply->setHeaderToNetwork();
         msg_sendto(m_fd, msgReply->getBuf(), length, reinterpret_cast<sockaddr *>(&sendto_addr), sendto_len);
         /*if (ret == RET_SOCKET_SHUTDOWN) {
@@ -2771,6 +2776,7 @@ inline bool CallbackMessageHandler<T>::handle_message()
             return VMA_PACKET_DROP;
         }*/
         msgReply->setHeaderToHost();
+        msgReply->setLength(request_length);
     }
 
     return true;


### PR DESCRIPTION
This adds a new optional argument to support a different packet reply size than the request size.  I added this because a customer asked me to simulate a "small request, large reply" situation such as one might have with a database query.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `--reply-size` command-line option for `under-load`, `ping-pong`, and `throughput` to control reply message payload size during testing, with validation and TCP/UDP-aware limit handling.
* **Bug Fixes**
  * Pong reply payloads now correctly honor the configured `--reply-size` (using the original request length as the fallback when set to `0`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->