### PR TITLE
issue: 5148137 Use tls detection flags in tls.m4 link-test

### DIFF
--- a/config/m4/tls.m4
+++ b/config/m4/tls.m4
@@ -32,7 +32,6 @@ AS_IF([test "x$with_tls" == xno],
         sockperf_cv_tls_lib_str="openssl"
 
         sockperf_cv_tls_save_CPPFLAGS="$CPPFLAGS"
-        sockperf_cv_tls_save_CXXFLAGS="$CXXFLAGS"
         sockperf_cv_tls_save_CFLAGS="$CFLAGS"
         sockperf_cv_tls_save_LDFLAGS="$LDFLAGS"
         sockperf_cv_tls_save_LIBS="$LIBS"
@@ -45,8 +44,7 @@ AS_IF([test "x$with_tls" == xno],
         fi
 
         CPPFLAGS="$sockperf_cv_tls_CPPFLAGS $CPPFLAGS"
-        CXXFLAGS="$sockperf_cv_dpcp_CXXFLAGS $CXXFLAGS"
-        LDFLAGS="$sockperf_cv_dpcp_LDFLAGS $LDFLAGS"
+        LDFLAGS="$sockperf_cv_tls_LDFLAGS $LDFLAGS"
         LIBS="$sockperf_cv_tls_LIBS $LIBS"
 
         AC_LANG_PUSH([C])
@@ -61,11 +59,11 @@ AS_IF([test "x$with_tls" == xno],
                   SSL_load_error_strings();
                 ]])],
                 [], [sockperf_cv_tls_lib=0])
-            ])
+            ],
+            [sockperf_cv_tls_lib=0])
         AC_LANG_POP()
 
         CPPFLAGS="$sockperf_cv_tls_save_CPPFLAGS"
-        CXXFLAGS="$sockperf_cv_tls_save_CXXFLAGS"
         CFLAGS="$sockperf_cv_tls_save_CFLAGS"
         LDFLAGS="$sockperf_cv_tls_save_LDFLAGS"
         LIBS="$sockperf_cv_tls_save_LIBS"
@@ -81,5 +79,7 @@ if test "$sockperf_cv_tls_lib" -ne 0; then
     AC_MSG_RESULT([$sockperf_cv_tls_lib_str])
 else
     AC_MSG_RESULT([no])
+    AS_IF([test "x$with_tls" != xno],
+        [AC_MSG_ERROR([TLS support was requested via --with-tls but the OpenSSL headers/libraries could not be found or failed the link test in "$with_tls"; install the OpenSSL development files or pass --with-tls=DIR with the correct prefix])])
 fi
 ])


### PR DESCRIPTION
The TLS support link-test applied $sockperf_cv_dpcp_LDFLAGS and $sockperf_cv_dpcp_CXXFLAGS, which are never set in this macro, instead of the $sockperf_cv_tls_* variables assigned just above. With OpenSSL in a non-default prefix the detection link-test could not find -lssl, so detection failed and TLS was silently disabled
(checking for tls support... no).

Use $sockperf_cv_tls_LDFLAGS so the OpenSSL -L/-rpath derived from --with-tls=<prefix> reach the link-test.

Remove CXXFLAGS usage, because it's unused in the C mode check.

Hard fail the configure stage if --with-tls requested and openssl is not found or the link test fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS-enabled builds by applying the correct TLS-specific compiler and linker flags during configuration.
  * Adjusted detection behavior so TLS library/header checks are handled more reliably.
  * When TLS is explicitly requested and isn’t usable, configuration now fails with a clear error instead of proceeding with a “no TLS” outcome.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->